### PR TITLE
Add `GetWeekSchedule` endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,14 +30,21 @@ type apiResponse struct {
 	Payload *json.RawMessage
 }
 
-func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage, error) {
-	theurl := s.baseurl
-	params := url.Values{
+/// apiRequestWithParams conducts a GET request with custom parameters.
+func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params map[string][]string) (*json.RawMessage, error) {
+	urlParams := url.Values{
 		"api_key": []string{s.apikey},
 		"mixins":  []string{strings.Join(mixins, ",")},
 	}
+	for k, vs := range params {
+		for _, v := range vs {
+			urlParams.Add(k, v)
+		}
+	}
+
+	theurl := s.baseurl
 	theurl.Path += endpoint
-	theurl.RawQuery = params.Encode()
+	theurl.RawQuery = urlParams.Encode()
 	req, err := http.NewRequest("GET", theurl.String(), nil)
 	if err != nil {
 		return nil, err
@@ -61,4 +68,9 @@ func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage
 		return nil, fmt.Errorf(endpoint + fmt.Sprintf(" Response not OK: %v", resJson))
 	}
 	return resJson.Payload, nil
+}
+
+/// apiRequest performs a GET request without custom params.
+func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage, error) {
+	return s.apiRequestWithParams(endpoint, mixins, map[string][]string{})
 }

--- a/api.go
+++ b/api.go
@@ -30,7 +30,7 @@ type apiResponse struct {
 	Payload *json.RawMessage
 }
 
-/// apiRequestWithParams conducts a GET request with custom parameters.
+// apiRequestWithParams conducts a GET request with custom parameters.
 func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params map[string][]string) (*json.RawMessage, error) {
 	urlParams := url.Values{
 		"api_key": []string{s.apikey},
@@ -70,7 +70,7 @@ func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params 
 	return resJson.Payload, nil
 }
 
-/// apiRequest performs a GET request without custom params.
+// apiRequest performs a GET request without custom params.
 func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage, error) {
 	return s.apiRequestWithParams(endpoint, mixins, map[string][]string{})
 }

--- a/api.go
+++ b/api.go
@@ -70,7 +70,7 @@ func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params 
 	return resJson.Payload, nil
 }
 
-// apiRequest performs a GET request without custom params.
+// apiRequest conducts a GET request without custom parameters.
 func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage, error) {
 	return s.apiRequestWithParams(endpoint, mixins, map[string][]string{})
 }

--- a/timeslot.go
+++ b/timeslot.go
@@ -68,6 +68,8 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 	return &currentAndNext, nil
 }
 
+// GetWeekSchedule gets the weekly schedule for ISO 8601 week week of year year.
+// It returns the result as a map from weekdays to lists of timeslots for that weekday.
 func (s *Session) GetWeekSchedule(year, week int) (map[time.Weekday][]Timeslot, error) {
 	// TODO(CaptainHayashi): proper errors
 	if year < 0 {

--- a/timeslot.go
+++ b/timeslot.go
@@ -69,10 +69,10 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 }
 
 // GetWeekSchedule gets the weekly schedule for ISO 8601 week week of year year.
-// It returns the result as an array of seven timeslot slices.
-// The array starts with index 0 being Monday and end with index 6 being Sunday.
+// It returns the result as an map from ISO 8601 weekdays to timeslot slices.
+// Thus, 1 maps to Monday's timeslots; 2 to Tuesday; and so on.
 // Each slice progresses chronologically from start of URY day to finish of URY day.
-func (s *Session) GetWeekSchedule(year, week int) ([][]Timeslot, error) {
+func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 	// TODO(CaptainHayashi): proper errors
 	if year < 0 {
 		return nil, fmt.Errorf("year %d is too low", year)
@@ -96,15 +96,13 @@ func (s *Session) GetWeekSchedule(year, week int) ([][]Timeslot, error) {
 	}
 
 	// Now convert the string keys into proper indices.
-	timeslots := make([][]Timeslot, 7)
+	timeslots := make(map[int][]Timeslot)
 	for sday, ts := range stringyTimeslots {
 		day, err := strconv.Atoi(sday)
 		if err != nil {
 			return nil, err
 		}
-
-		// We use 0-based indexing.
-		timeslots[day-1] = ts
+		timeslots[day] = ts
 	}
 
 	return timeslots, nil


### PR DESCRIPTION
This adds a new method to `Timeslot`, `GetWeekSchedule`, which wraps the MyRadio `/timeslot/weekschedule` endpoint.

To do this, I needed to add custom parameters to the `GET` request, so I made a new `apiRequestWithParams` method and pointed `apiRequest` to it for backwards compatibility.