### PR TITLE
Fix most (but not all) gometalinter complaints.

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 )
 
+// Alias represents a mail alias.
 type Alias struct {
 	Id           int `json:"alias_id"`
 	Source       string
@@ -13,6 +14,11 @@ type Alias struct {
 	}
 }
 
+// GetAllAliases retrieves all aliases in use.
+//
+// It takes a list of additional MyRadio API mixins to use when retrieving the aliases.
+//
+// This consumes one API request.
 func (s *Session) GetAllAliases(mixins []string) ([]Alias, error) {
 	data, err := s.apiRequest("/alias/allaliases", mixins)
 	if err != nil {

--- a/alias.go
+++ b/alias.go
@@ -15,9 +15,7 @@ type Alias struct {
 }
 
 // GetAllAliases retrieves all aliases in use.
-//
 // It takes a list of additional MyRadio API mixins to use when retrieving the aliases.
-//
 // This consumes one API request.
 func (s *Session) GetAllAliases(mixins []string) ([]Alias, error) {
 	data, err := s.apiRequest("/alias/allaliases", mixins)

--- a/api.go
+++ b/api.go
@@ -62,15 +62,15 @@ func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params 
 	if err != nil {
 		return nil, err
 	}
-	var resJson apiResponse
-	err = json.Unmarshal(data, &resJson)
+	var response apiResponse
+	err = json.Unmarshal(data, &response)
 	if err != nil {
 		return nil, err
 	}
-	if resJson.Status != "OK" {
-		return nil, fmt.Errorf(endpoint + fmt.Sprintf(" Response not OK: %v", resJson))
+	if response.Status != "OK" {
+		return nil, fmt.Errorf(endpoint + fmt.Sprintf(" Response not OK: %v", response))
 	}
-	return resJson.Payload, nil
+	return response.Payload, nil
 }
 
 // apiRequest conducts a GET request without custom parameters.

--- a/api.go
+++ b/api.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 )
 
+// Session represents an open API session.
 type Session struct {
 	apikey  string
 	baseurl url.URL
 }
 
+// NewSession constructs a new Session with the given API key.
 func NewSession(apikey string) (*Session, error) {
 	url, err := url.Parse(`https://ury.york.ac.uk/api/v2`)
 	if err != nil {
@@ -25,6 +27,7 @@ func NewSession(apikey string) (*Session, error) {
 	}, nil
 }
 
+// apiResponse provides the base structure of MyRadio API responses.
 type apiResponse struct {
 	Status  string
 	Payload *json.RawMessage

--- a/key.go
+++ b/key.go
@@ -73,7 +73,6 @@ func getAPIKeyFromFile(path string) string {
 }
 
 // NewSessionFromKeyFile tries to open a Session with the key from an API key file.
-//
 // This tries the following paths for a file containing one line (the API key):
 //   1) Whichever path is set in the environment variable `MYRADIOKEYFILE`;
 //   2) `.myradio.key`, in the current directory;

--- a/key.go
+++ b/key.go
@@ -28,15 +28,17 @@ var KeyFiles = []string{
 	"/usr/local/etc/myradio.key",
 }
 
-func getApiKey() (apikey string, err error) {
-	apikey, err = getApiKeyEnv()
+// getAPIKey tries to get an API key from all possible sources.
+func getAPIKey() (apikey string, err error) {
+	apikey, err = getAPIKeyEnv()
 	if err != nil {
-		apikey, err = getApiKeyFile()
+		apikey, err = getAPIKeyFile()
 	}
 	return
 }
 
-func getApiKeyEnv() (apikey string, err error) {
+// getAPIKey tries to get an API key from the environment.
+func getAPIKeyEnv() (apikey string, err error) {
 	apikey, err = os.Getenv("MYRADIOKEYFILE"), nil
 	if apikey == "" {
 		err = ErrNoMYRADIOKEYFILE
@@ -44,9 +46,10 @@ func getApiKeyEnv() (apikey string, err error) {
 	return
 }
 
-func getApiKeyFile() (apikey string, err error) {
+// getAPIKeyFile tries to get an API key from a known file.
+func getAPIKeyFile() (apikey string, err error) {
 	for _, rawPath := range KeyFiles {
-		apikey = getApiKeyFromFile(rawPath)
+		apikey = getAPIKeyFromFile(rawPath)
 		if apikey != "" {
 			return
 		}
@@ -57,9 +60,9 @@ func getApiKeyFile() (apikey string, err error) {
 	return
 }
 
-// getApiKeyFromFile tries to get an apikey from a file.
+// getAPIKeyFromFile tries to get an apikey from a file.
 // Returns an empty string if it fails
-func getApiKeyFromFile(path string) string {
+func getAPIKeyFromFile(path string) string {
 	path = os.ExpandEnv(path)
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -78,7 +81,7 @@ func getApiKeyFromFile(path string) string {
 //   4) `/etc/myradio.key`;
 //   5) `/usr/local/etc/myradio.key`.
 func NewSessionFromKeyFile() (*Session, error) {
-	apikey, err := getApiKey()
+	apikey, err := getAPIKey()
 	if err != nil {
 		return nil, err
 	}

--- a/key_test.go
+++ b/key_test.go
@@ -14,7 +14,7 @@ func TestGetApiKeyFromFile(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		k := getApiKeyFromFile(test.Path)
+		k := getAPIKeyFromFile(test.Path)
 		if k != test.Expected {
 			t.Fail()
 		}

--- a/lists.go
+++ b/lists.go
@@ -14,7 +14,6 @@ type List struct {
 }
 
 // GetAllLists retrieves all mailing lists in the MyRadio system.
-//
 // This consumes one API request.
 func (s *Session) GetAllLists() ([]List, error) {
 	data, err := s.apiRequest("/list/alllists", nil)
@@ -30,7 +29,6 @@ func (s *Session) GetAllLists() ([]List, error) {
 }
 
 // GetMembers retrieves all members subscribed to a given mailing list.
-//
 // This consumes one API request.
 func (s *Session) GetMembers(l *List) ([]Member, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/list/%d/members", l.Listid), []string{"personal_data"})

--- a/lists.go
+++ b/lists.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// List represents a mailing list.
 type List struct {
 	Listid     int
 	Name       string
@@ -12,6 +13,9 @@ type List struct {
 	Recipients int `json:"recipient_count"`
 }
 
+// GetAllLists retrieves all mailing lists in the MyRadio system.
+//
+// This consumes one API request.
 func (s *Session) GetAllLists() ([]List, error) {
 	data, err := s.apiRequest("/list/alllists", nil)
 	if err != nil {
@@ -25,6 +29,9 @@ func (s *Session) GetAllLists() ([]List, error) {
 	return lists, nil
 }
 
+// GetMembers retrieves all members subscribed to a given mailing list.
+//
+// This consumes one API request.
 func (s *Session) GetMembers(l *List) ([]Member, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/list/%d/members", l.Listid), []string{"personal_data"})
 	if err != nil {

--- a/member.go
+++ b/member.go
@@ -15,7 +15,6 @@ type Member struct {
 }
 
 // GetMember retrieves the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetMember(id int) (*Member, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d", id), []string{"personal_data"})

--- a/member.go
+++ b/member.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Member represents a MyRadio user.
 type Member struct {
 	Memberid     int
 	Fname, Sname string
@@ -13,6 +14,9 @@ type Member struct {
 	Receiveemail bool   `json:"receive_email"`
 }
 
+// GetMember retrieves the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetMember(id int) (*Member, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d", id), []string{"personal_data"})
 	if err != nil {

--- a/officer.go
+++ b/officer.go
@@ -27,9 +27,7 @@ type OfficerPosition struct {
 }
 
 // GetAllOfficerPositions retrieves all officer positions in MyRadio.
-//
 // The amount of detail can be controlled by adding MyRadio mixins.
-//
 // This consumes one API request.
 func (s *Session) GetAllOfficerPositions(mixins []string) ([]OfficerPosition, error) {
 	data, err := s.apiRequest("/officer/allofficerpositions", mixins)

--- a/officer.go
+++ b/officer.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// OfficerPosition represents a specific station officer position.
 type OfficerPosition struct {
 	OfficerID   int
 	Name        string
@@ -25,6 +26,11 @@ type OfficerPosition struct {
 	} `json:"history,omitempty"`
 }
 
+// GetAllOfficerPositions retrieves all officer positions in MyRadio.
+//
+// The amount of detail can be controlled by adding MyRadio mixins.
+//
+// This consumes one API request.
 func (s *Session) GetAllOfficerPositions(mixins []string) ([]OfficerPosition, error) {
 	data, err := s.apiRequest("/officer/allofficerpositions", mixins)
 	if err != nil {

--- a/season.go
+++ b/season.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// GetSeason retrieves the season with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetSeason(id int) (season Season, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/season/%d/", id), []string{})
 	if err != nil {
@@ -23,6 +26,9 @@ func (s *Session) GetSeason(id int) (season Season, err error) {
 	return
 }
 
+// GetTimeslotsForSeason retrieves all timeslots for the season with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/season/%d/alltimeslots/", id), []string{})
 	if err != nil {

--- a/season.go
+++ b/season.go
@@ -7,7 +7,6 @@ import (
 )
 
 // GetSeason retrieves the season with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetSeason(id int) (season Season, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/season/%d/", id), []string{})
@@ -27,7 +26,6 @@ func (s *Session) GetSeason(id int) (season Season, err error) {
 }
 
 // GetTimeslotsForSeason retrieves all timeslots for the season with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/season/%d/alltimeslots/", id), []string{})

--- a/show.go
+++ b/show.go
@@ -7,12 +7,16 @@ import (
 	"time"
 )
 
+// Credit represents a show credit associating a user with a show.
 type Credit struct {
 	Type     int    `json:"type"`
 	MemberID int    `json:"memberid"`
 	User     Member `json:"User"`
 }
 
+// ShowMeta represents a show in the MyRadio schedule.
+//
+// A MyRadio show contains seasons, each containing timeslots.
 // @TODO: Refactor this to something better named
 type ShowMeta struct {
 	ShowID        int      `json:"show_id"`
@@ -28,6 +32,7 @@ type ShowMeta struct {
 	Photo         string   `json:"photo"`
 }
 
+// Link represents a MyRadio action link.
 type Link struct {
 	Display string      `json:"display"`
 	Value   interface{} `json:"value"`
@@ -35,6 +40,9 @@ type Link struct {
 	URL     string      `json:"url"`
 }
 
+// Season represents a season in the MyRadio schedule.
+//
+// A MyRadio season contains timeslots.
 type Season struct {
 	ShowMeta
 	SeasonID      int    `json:"season_id"`
@@ -49,6 +57,9 @@ type Season struct {
 	RejectLink    Link `json:"rejectlink"`
 }
 
+// GetSearchMeta retrieves all shows whose metadata matches a given search term.
+//
+// This consumes one API request.
 func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
 
 	q := url.QueryEscape(term)
@@ -71,6 +82,9 @@ func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
 
 }
 
+// GetShow retrieves the show with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetShow(id int) (*ShowMeta, error) {
 
 	data, err := s.apiRequest(fmt.Sprintf("/show/%d", id), []string{})
@@ -91,6 +105,9 @@ func (s *Session) GetShow(id int) (*ShowMeta, error) {
 
 }
 
+// GetSeasons retrieves the seasons of the show with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/show/%d/allseasons", id), []string{})
 	if err != nil {

--- a/show.go
+++ b/show.go
@@ -15,7 +15,6 @@ type Credit struct {
 }
 
 // ShowMeta represents a show in the MyRadio schedule.
-//
 // A MyRadio show contains seasons, each containing timeslots.
 // @TODO: Refactor this to something better named
 type ShowMeta struct {
@@ -41,7 +40,6 @@ type Link struct {
 }
 
 // Season represents a season in the MyRadio schedule.
-//
 // A MyRadio season contains timeslots.
 type Season struct {
 	ShowMeta
@@ -58,7 +56,6 @@ type Season struct {
 }
 
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.
-//
 // This consumes one API request.
 func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
 
@@ -83,7 +80,6 @@ func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
 }
 
 // GetShow retrieves the show with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetShow(id int) (*ShowMeta, error) {
 
@@ -106,7 +102,6 @@ func (s *Session) GetShow(id int) (*ShowMeta, error) {
 }
 
 // GetSeasons retrieves the seasons of the show with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/show/%d/allseasons", id), []string{})

--- a/team.go
+++ b/team.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Position represents a MyRadio officer position.
 type Position struct {
 	Team        Team   `json:"team"`
 	OfficerID   uint   `json:"officerid"`
@@ -17,6 +18,7 @@ type Position struct {
 	Type        string `json:"type"`
 }
 
+// Officer represents information about an officership inside a Team.
 type Officer struct {
 	User            Member `json:"user"`
 	From            time.Time
@@ -25,6 +27,7 @@ type Officer struct {
 	Position        Position `json:"position"`
 }
 
+// Team represents a station committee team.
 type Team struct {
 	TeamID      uint      `json:"teamid"`
 	Name        string    `json:"name"`
@@ -35,6 +38,7 @@ type Team struct {
 	Officers    []Officer `json:"officers"`
 }
 
+// HeadPosition represents the head position of a team.
 type HeadPosition struct {
 	User            Member
 	From            int
@@ -42,6 +46,9 @@ type HeadPosition struct {
 	Position        OfficerPosition
 }
 
+// GetCurrentTeams retrieves all teams inside the station committee.
+//
+// This consumes one API request.
 func (s *Session) GetCurrentTeams() (teams []Team, err error) {
 	data, err := s.apiRequest("/team/currentteams/", []string{})
 	if err != nil {
@@ -54,6 +61,9 @@ func (s *Session) GetCurrentTeams() (teams []Team, err error) {
 	return
 }
 
+// GetTeamWithOfficers retrieves a team record with officer information for the given team name.
+//
+// This consumes one API request.
 func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/team/byalias/%s", teamName), []string{"officers"})
 	if err != nil {
@@ -69,6 +79,11 @@ func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
 	return
 }
 
+// GetTeamHeadPositions retrieves all head-of-team positions for a given team ID.
+//
+// The amount of detail can be controlled using MyRadio mixins.
+//
+// This consumes one API request.
 func (s *Session) GetTeamHeadPositions(id int, mixins []string) (head []HeadPosition, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/team/%d/headpositions", id), mixins)
 	if err != nil {

--- a/team.go
+++ b/team.go
@@ -47,7 +47,6 @@ type HeadPosition struct {
 }
 
 // GetCurrentTeams retrieves all teams inside the station committee.
-//
 // This consumes one API request.
 func (s *Session) GetCurrentTeams() (teams []Team, err error) {
 	data, err := s.apiRequest("/team/currentteams/", []string{})
@@ -62,7 +61,6 @@ func (s *Session) GetCurrentTeams() (teams []Team, err error) {
 }
 
 // GetTeamWithOfficers retrieves a team record with officer information for the given team name.
-//
 // This consumes one API request.
 func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/team/byalias/%s", teamName), []string{"officers"})
@@ -80,9 +78,7 @@ func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
 }
 
 // GetTeamHeadPositions retrieves all head-of-team positions for a given team ID.
-//
 // The amount of detail can be controlled using MyRadio mixins.
-//
 // This consumes one API request.
 func (s *Session) GetTeamHeadPositions(id int, mixins []string) (head []HeadPosition, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/team/%d/headpositions", id), mixins)

--- a/timeslot.go
+++ b/timeslot.go
@@ -28,7 +28,6 @@ type Show struct {
 }
 
 // Timeslot contains information about a single timeslot in the URY schedule.
-//
 // A timeslot is a single slice of time on the schedule, typically one hour long.
 type Timeslot struct {
 	Season
@@ -58,7 +57,6 @@ type TracklistItem struct {
 }
 
 // GetCurrentAndNext gets the current and next shows at the time of the call.
-//
 // This consumes one API request.
 func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 	data, err := s.apiRequest("/timeslot/currentandnext", []string{})
@@ -78,11 +76,9 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 }
 
 // GetWeekSchedule retrieves the weekly schedule for ISO 8601 week week of year year.
-//
 // It returns the result as an map from ISO 8601 weekdays to timeslot slices.
 // Thus, 1 maps to Monday's timeslots; 2 to Tuesday; and so on.
 // Each slice progresses chronologically from start of URY day to finish of URY day.
-//
 // This consumes one API request.
 func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 	// TODO(CaptainHayashi): proper errors
@@ -121,7 +117,6 @@ func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 }
 
 // GetTimeslot retrieves the timeslot with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/timeslot/%d", id), []string{})
@@ -150,7 +145,6 @@ func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
 }
 
 // GetTrackListForTimeslot retrieves the tracklist for the timeslot with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetTrackListForTimeslot(id int) (tracklist []TracklistItem, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/tracklistItem/tracklistfortimeslot/%d", id), []string{})

--- a/timeslot.go
+++ b/timeslot.go
@@ -7,11 +7,13 @@ import (
 	"time"
 )
 
+// CurrentAndNext stores a pair of current and next show.
 type CurrentAndNext struct {
 	Next    Show `json:"next"`
 	Current Show `json:"current"`
 }
 
+// Show contains a summary of information about a URY schedule timeslot.
 type Show struct {
 	Title        string `json:"title"`
 	Desc         string `json:"desc"`
@@ -25,6 +27,9 @@ type Show struct {
 	Id           uint64 `json:"id,omitempty"`
 }
 
+// Timeslot contains information about a single timeslot in the URY schedule.
+//
+// A timeslot is a single slice of time on the schedule, typically one hour long.
 type Timeslot struct {
 	Season
 	TimeslotID     uint64   `json:"timeslot_id"`
@@ -39,6 +44,7 @@ type Timeslot struct {
 	MixcloudStatus string `json:"mixcloud_status"`
 }
 
+// TracklistItem represents a single item in a show tracklist.
 type TracklistItem struct {
 	Track
 	Album        Album `json:"album"`
@@ -51,6 +57,9 @@ type TracklistItem struct {
 	AudioLogID   uint   `json:"audiologid"`
 }
 
+// GetCurrentAndNext gets the current and next shows at the time of the call.
+//
+// This consumes one API request.
 func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 	data, err := s.apiRequest("/timeslot/currentandnext", []string{})
 	if err != nil {
@@ -68,10 +77,13 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 	return &currentAndNext, nil
 }
 
-// GetWeekSchedule gets the weekly schedule for ISO 8601 week week of year year.
+// GetWeekSchedule retrieves the weekly schedule for ISO 8601 week week of year year.
+//
 // It returns the result as an map from ISO 8601 weekdays to timeslot slices.
 // Thus, 1 maps to Monday's timeslots; 2 to Tuesday; and so on.
 // Each slice progresses chronologically from start of URY day to finish of URY day.
+//
+// This consumes one API request.
 func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 	// TODO(CaptainHayashi): proper errors
 	if year < 0 {
@@ -108,6 +120,9 @@ func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 	return timeslots, nil
 }
 
+// GetTimeslot retrieves the timeslot with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/timeslot/%d", id), []string{})
 	if err != nil {
@@ -134,6 +149,9 @@ func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
 	return
 }
 
+// GetTrackListForTimeslot retrieves the tracklist for the timeslot with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetTrackListForTimeslot(id int) (tracklist []TracklistItem, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/tracklistItem/tracklistfortimeslot/%d", id), []string{})
 	if err != nil {

--- a/tracks.go
+++ b/tracks.go
@@ -31,7 +31,7 @@ type Album struct {
 	// ShelfLetter is the shelf on which the physical copy resides, if any.
 	ShelfLetter string `json:"shelf_letter"`
 	// ShelfNumber is the position on the shelf on which the physical copy resides, if any.
-	ShelfNumber string `json:"shelf_number"`
+	ShelfNumber uint64 `json:"shelf_number"`
 
 	// Format is a single-character code identifying the physical format.
 	Format string `json:"format"`

--- a/tracks.go
+++ b/tracks.go
@@ -9,66 +9,66 @@ import (
 // Album contains information about an album in the URY track database.
 type Album struct {
 	// ID is the unique database ID of the album.
-	ID uint64 `json:recordid`
+	ID uint64 `json:"recordid"`
 
 	// Title is the title of the track.
-	Title string `json:title`
+	Title string `json:"title"`
 	// Artist is the primary credited artist of the track.
-	Artist string `json:artist`
+	Artist string `json:"artist"`
 
 	// DateAdded is the date on which the album entered the MyRadio library.
-	DateAdded string `json:date_added`
+	DateAdded string `json:"date_added"`
 	// DateReleased is the date on which the album was released.
-	DateReleased string `json:date_released`
+	DateReleased string `json:"date_released"`
 	// LastModified is the date on which the album was last modified.
-	LastModified string `json:last_modified`
+	LastModified string `json:"last_modified"`
 
 	// CDID is the ID of the CD, if this track comes from one.
-	CDID string `json:cdid`
+	CDID string `json:"cdid"`
 
 	// Location is the location of the physical copy of this album, if any.
-	Location string `json:location`
+	Location string `json:"location"`
 	// ShelfLetter is the shelf on which the physical copy resides, if any.
-	ShelfLetter string `json:shelf_letter`
+	ShelfLetter string `json:"shelf_letter"`
 	// ShelfNumber is the position on the shelf on which the physical copy resides, if any.
-	ShelfNumber string `json:shelf_number`
+	ShelfNumber string `json:"shelf_number"`
 
 	// Format is a single-character code identifying the physical format.
-	Format string `json:format`
+	Format string `json:"format"`
 	// Medium is a single-character code identifying the physical medium.
-	Medium string `json:media`
+	Medium string `json:"media"`
 
 	// AddingMember is the ID of the member who added this album.
-	AddingMember uint64 `json:member_add`
+	AddingMember uint64 `json:"member_add"`
 	// EditingMember is the ID of the member who last modified this album.
-	EditingMember uint64 `json:member_edit`
+	EditingMember uint64 `json:"member_edit"`
 
 	// RecordLabel is the record label responsible for this album.
-	RecordLabel string `json:record_label`
+	RecordLabel string `json:"record_label"`
 
 	// Status is the digitisation status code for this album.
-	Status string `json:status`
+	Status string `json:"status"`
 }
 
 // Track contains information about a track in the URY track database.
 type Track struct {
 	// ID is the unique database ID of the track.
-	ID uint64 `json:trackid`
+	ID uint64 `json:"trackid"`
 
 	// Title is the title of the track.
-	Title string `json:title`
+	Title string `json:"title"`
 	// Artist is the primary credited artist of the track.
-	Artist string `json:artist`
+	Artist string `json:"artist"`
 	// Type is the type ('central' etc.) of the track.
-	Type string `json:type`
+	Type string `json:"type"`
 	// Length is the length of the track, in hours:minutes:seconds.
-	Length string `json:length`
+	Length string `json:"length"`
 	// Intro is length of the track's intro, in seconds.
-	Intro uint64 `json:intro`
+	Intro uint64 `json:"intro"`
 	// IsClean is true if this track is clean (no expletives).
-	IsClean bool `json:clean`
+	IsClean bool `json:"clean"`
 	// IsDigitised is true if this track is available in the playout system.
-	IsDigitised bool `json:digitised`
+	IsDigitised bool `json:"digitised"`
 }
 
 // GetAlbum tries to get the Album for the given Track.

--- a/tracks.go
+++ b/tracks.go
@@ -72,16 +72,13 @@ type Track struct {
 }
 
 // GetAlbum tries to get the Album for the given Track.
-//
 // This consumes one API request.
 func (t *Track) GetAlbum(s *Session) (*Album, error) {
 	return s.GetTrackAlbum(t.ID)
 }
 
 // LengthSec returns the track's length in seconds.
-//
 // Returns an error if the track's length is ill-formed.
-//
 // This consumes no API requests.
 func (t *Track) LengthSec() (uint64, error) {
 	var hours, minutes, seconds uint64
@@ -95,12 +92,9 @@ func (t *Track) LengthSec() (uint64, error) {
 }
 
 // LengthUsec returns the track's length in microseconds.
-//
 // This is not precise, as it is derived from the length in seconds.
 // Consider estimating the correct length from the track file itself.
-//
 // Returns an error if the track's length is ill-formed.
-//
 // This consumes no API requests.
 func (t *Track) LengthUsec() (uint64, error) {
 	secs, err := t.LengthSec()
@@ -112,16 +106,13 @@ func (t *Track) LengthUsec() (uint64, error) {
 }
 
 // IntroUsec returns the track's intro in microseconds.
-//
 // This consumes no API requests.
 func (t *Track) IntroUsec() uint64 {
 	return t.Intro * 1000000
 }
 
 // GetTrack tries to get the Track with the given ID.
-//
 // Track IDs are unique, so we do not need the record ID.
-//
 // This consumes one API request.
 func (s *Session) GetTrack(trackid uint64) (*Track, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/track/%d", trackid), nil)
@@ -137,7 +128,6 @@ func (s *Session) GetTrack(trackid uint64) (*Track, error) {
 }
 
 // GetTrackTitle tries to get the title of the track with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetTrackTitle(trackid uint64) (string, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/track/%d/title", trackid), nil)
@@ -153,7 +143,6 @@ func (s *Session) GetTrackTitle(trackid uint64) (string, error) {
 }
 
 // GetTrackAlbum tries to get the Album of the track with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetTrackAlbum(trackid uint64) (*Album, error) {
 	data, err := s.apiRequest(fmt.Sprintf("/track/%d/album", trackid), nil)

--- a/user.go
+++ b/user.go
@@ -7,6 +7,7 @@ import (
 	"time"
 )
 
+// Officership represents an officership a user holds.
 type Officership struct {
 	OfficerId   uint   `json:"officerid,string"`
 	OfficerName string `json:"officer_name"`
@@ -17,6 +18,7 @@ type Officership struct {
 	TillDate    time.Time
 }
 
+// Photo represents a photo of a user.
 type Photo struct {
 	PhotoId      uint   `json:"photoid"`
 	DateAddedRaw string `json:"date_added"`
@@ -26,11 +28,15 @@ type Photo struct {
 	Url          string `json:"url"`
 }
 
+// UserAlias represents a user alias.
 type UserAlias struct {
 	Source      string
 	Destination string
 }
 
+// GetUserBio retrieves the biography of the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserBio(id int) (bio string, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/bio/", id), []string{})
 	if err != nil {
@@ -44,6 +50,9 @@ func (s *Session) GetUserBio(id int) (bio string, err error) {
 	return
 }
 
+// GetUserName retrieves the name of the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserName(id int) (name string, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/name/", id), []string{})
 	if err != nil {
@@ -53,6 +62,9 @@ func (s *Session) GetUserName(id int) (name string, err error) {
 	return
 }
 
+// GetUserProfilePhoto retrieves the profile photo of the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserProfilePhoto(id int) (profilephoto Photo, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/profilephoto/", id), []string{})
 	if err != nil {
@@ -70,6 +82,9 @@ func (s *Session) GetUserProfilePhoto(id int) (profilephoto Photo, err error) {
 	return
 }
 
+// GetUserOfficerships retrieves all officerships held by the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserOfficerships(id int) (officerships []Officership, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/officerships/", id), []string{})
 	if err != nil {
@@ -96,6 +111,9 @@ func (s *Session) GetUserOfficerships(id int) (officerships []Officership, err e
 	return
 }
 
+// GetUserShowCredits retrieves all show credits associated with the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserShowCredits(id int) (shows []ShowMeta, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/shows/", id), []string{})
 	if err != nil {
@@ -105,6 +123,9 @@ func (s *Session) GetUserShowCredits(id int) (shows []ShowMeta, err error) {
 	return
 }
 
+// GetUserAliases retrieves all aliases associated with the user with the given ID.
+//
+// This consumes one API request.
 func (s *Session) GetUserAliases() ([]UserAlias, error) {
 	data, err := s.apiRequest("/user/allaliases/", []string{})
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -35,7 +35,6 @@ type UserAlias struct {
 }
 
 // GetUserBio retrieves the biography of the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserBio(id int) (bio string, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/bio/", id), []string{})
@@ -51,7 +50,6 @@ func (s *Session) GetUserBio(id int) (bio string, err error) {
 }
 
 // GetUserName retrieves the name of the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserName(id int) (name string, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/name/", id), []string{})
@@ -63,7 +61,6 @@ func (s *Session) GetUserName(id int) (name string, err error) {
 }
 
 // GetUserProfilePhoto retrieves the profile photo of the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserProfilePhoto(id int) (profilephoto Photo, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/profilephoto/", id), []string{})
@@ -83,7 +80,6 @@ func (s *Session) GetUserProfilePhoto(id int) (profilephoto Photo, err error) {
 }
 
 // GetUserOfficerships retrieves all officerships held by the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserOfficerships(id int) (officerships []Officership, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/officerships/", id), []string{})
@@ -112,7 +108,6 @@ func (s *Session) GetUserOfficerships(id int) (officerships []Officership, err e
 }
 
 // GetUserShowCredits retrieves all show credits associated with the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserShowCredits(id int) (shows []ShowMeta, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/user/%d/shows/", id), []string{})
@@ -124,7 +119,6 @@ func (s *Session) GetUserShowCredits(id int) (shows []ShowMeta, err error) {
 }
 
 // GetUserAliases retrieves all aliases associated with the user with the given ID.
-//
 // This consumes one API request.
 func (s *Session) GetUserAliases() ([]UserAlias, error) {
 	data, err := s.apiRequest("/user/allaliases/", []string{})

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package myradio
 import "time"
 
 // parseDuration takes a custom layout and a value and returns a time.Duration
-//
 // Not guaranteed to work so be careful with what you pass in.
 func parseDuration(layout, value string) (dur time.Duration, err error) {
 	// There is probably a more efficient way of doing this, but time.Unix(0,0) didn't want to work


### PR DESCRIPTION
This fixes a lot of low-hanging fruit with failing lints.

Most of the lints that haven't been fixed involve renaming _public_ fields (for example, `OfficerId` should be `OfficerID`), which I didn't do because I didn't want to break anyone else's code.

If everyone is ok with me changing the below, I will:
```
alias.go:9:2:warning: struct field Id should be ID (golint)
timeslot.go:26:2:warning: struct field Url should be URL (golint)
timeslot.go:27:2:warning: struct field Id should be ID (golint)
user.go:12:2:warning: struct field OfficerId should be OfficerID (golint)
user.go:14:2:warning: struct field TeamId should be TeamID (golint)
user.go:23:2:warning: struct field PhotoId should be PhotoID (golint)
user.go:28:2:warning: struct field Url should be URL (golint)
```

There are also some other lints that aren't working: `dupl` thinks that part of `tracks.go` is needlessly duplicated (it isn't), and another lint is unhappy with the fact that we're closing something but not handling errors on closing it.