### PR TITLE
Properly populate times for week schedule.

### DIFF
--- a/season.go
+++ b/season.go
@@ -52,7 +52,7 @@ func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error
 		if err != nil {
 			return
 		}
-		timeslots[k].Duration, err = parseDuration("15:04:05", v.DurationRaw)
+		timeslots[k].Duration, err = parseDuration(v.DurationRaw)
 		if err != nil {
 			return
 		}

--- a/show_test.go
+++ b/show_test.go
@@ -65,7 +65,7 @@ func TestGetSearchMetaUnmarshal(t *testing.T) {
 			{
 				Type:     1,
 				MemberID: 666,
-				User: myradio.Member{
+				User: myradio.User{
 					Memberid:     666,
 					Fname:        "Tommy",
 					Sname:        "Tutone",

--- a/timeslot.go
+++ b/timeslot.go
@@ -79,15 +79,17 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 func populateTimes(timeslot *Timeslot) error {
 	var err error = nil
 	timeslot.Time = time.Unix(timeslot.TimeRaw, 0)
-	timeslot.FirstTime, err = time.Parse("02/01/2006 15:04", timeslot.FirstTimeRaw)
+
+	// MyRadio returns local timestamps, not UTC.
+	timeslot.FirstTime, err = time.ParseInLocation("02/01/2006 15:04", timeslot.FirstTimeRaw, time.Local)
 	if err != nil {
 		return err
 	}
-	timeslot.Submitted, err = time.Parse("02/01/2006 15:04", timeslot.SubmittedRaw)
+	timeslot.Submitted, err = time.ParseInLocation("02/01/2006 15:04", timeslot.SubmittedRaw, time.Local)
 	if err != nil {
 		return err
 	}
-	timeslot.StartTime, err = time.Parse("02/01/2006 15:04", timeslot.StartTimeRaw)
+	timeslot.StartTime, err = time.ParseInLocation("02/01/2006 15:04", timeslot.StartTimeRaw, time.Local)
 	if err != nil {
 		return err
 	}
@@ -95,6 +97,7 @@ func populateTimes(timeslot *Timeslot) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/timeslot.go
+++ b/timeslot.go
@@ -93,7 +93,7 @@ func populateTimes(timeslot *Timeslot) error {
 	if err != nil {
 		return err
 	}
-	timeslot.Duration, err = parseDuration("15:04:05", timeslot.DurationRaw)
+	timeslot.Duration, err = parseDuration(timeslot.DurationRaw)
 	if err != nil {
 		return err
 	}

--- a/utils.go
+++ b/utils.go
@@ -1,18 +1,62 @@
 package myradio
 
-import "time"
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
 
-// parseDuration takes a time string of the form 'HH:MM:SS' and returns a time.Duration
-// Not guaranteed to work so be careful with what you pass in.
+// parseDuration parses durations in MyRadio's 'HH:MM:SS' format.
+// On success, it returns the equivalent duration; else, it reports an error.
+// Errors occur if the duration is not in the given format, or cannot be represented as a Duration.
+// For a negative duration, give (-HH:MM:SS).
 func parseDuration(value string) (dur time.Duration, err error) {
-	// There is probably a more efficient way of doing this, but time.Unix(0,0) didn't want to work
-	midnight, err := time.Parse("15:04:05", "00:00:00")
+	// @MattWindsor91:
+	// Previously, we relied on time.Parse to implement this.
+	// However, while convenient, this fails for durations that don't 'look' like times,
+	// eg. anything over 23:59:60.
+
+	vs := strings.Split(value, ":")
+	if len(vs) != 3 {
+		err = fmt.Errorf("parseDuration: '%s' has %i sections but should have 3", value, len(vs))
+		return
+	}
+
+	// If the entire thing is prefixed by a sign, then we need to handle that carefully.
+	// This is because just treating the hours as negative fails if the hours part is -0!
+	sign := 1
+	if 0 < len(vs[0]) && vs[0][0] == '-' {
+		vs[0] = strings.Replace(vs[0], "-", "0", -1)
+		sign = -1
+	}
+
+	// Save us from repeating the same processing logic 3 times, at the cost of some efficiency when we fail.
+	parseBit := func(bit string, min, max int64) (val int64) {
+		if err != nil {
+			return
+		}
+		val, err = strconv.ParseInt(bit, 10, 64)
+		if err != nil {
+			return
+		}
+
+		// At this stage, val will contain the parsed value: this is just an additional sanity check.
+		if val < min || max < val {
+			err = fmt.Errorf("parseDuration: expected %i-%i, got %i", min, max, val)
+		}
+
+		return
+	}
+
+	h := parseBit(vs[0], math.MinInt64, math.MaxInt64)
+	m := parseBit(vs[1], 0, 59)
+	s := parseBit(vs[2], 0, 59) // This is a duration, so we don't need to worry about leap seconds.
 	if err != nil {
 		return
 	}
-	t, err := time.Parse("15:04:05", value)
-	if err != nil {
-		return
-	}
-	return t.Sub(midnight), nil
+
+	dur = time.Duration(sign) * ((time.Duration(h) * time.Hour) + (time.Duration(m) * time.Minute) + (time.Duration(s) * time.Second))
+	return
 }

--- a/utils.go
+++ b/utils.go
@@ -2,15 +2,15 @@ package myradio
 
 import "time"
 
-// parseDuration takes a custom layout and a value and returns a time.Duration
+// parseDuration takes a time string of the form 'HH:MM:SS' and returns a time.Duration
 // Not guaranteed to work so be careful with what you pass in.
-func parseDuration(layout, value string) (dur time.Duration, err error) {
+func parseDuration(value string) (dur time.Duration, err error) {
 	// There is probably a more efficient way of doing this, but time.Unix(0,0) didn't want to work
 	midnight, err := time.Parse("15:04:05", "00:00:00")
 	if err != nil {
 		return
 	}
-	t, err := time.Parse(layout, value)
+	t, err := time.Parse("15:04:05", value)
 	if err != nil {
 		return
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,6 +12,7 @@ func TestParseDuration(t *testing.T) {
 	}{
 		{"2h", "02:00:00"},
 		{"30m", "00:30:00"},
+		{"30h", "30:00:00"},
 	}
 
 	for _, test := range tests {

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,7 +18,7 @@ func TestParseDuration(t *testing.T) {
 	for _, test := range tests {
 		// We can safely leave testing the time lib to the stl
 		expected, _ := time.ParseDuration(test.expectedStr)
-		got, err := parseDuration("15:04:05", test.time)
+		got, err := parseDuration(test.time)
 		if err != nil || got != expected {
 			t.Error("Got:", got, ", Expected:", expected, ", Error:", err)
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -13,6 +13,7 @@ func TestParseDuration(t *testing.T) {
 		{"2h", "02:00:00"},
 		{"30m", "00:30:00"},
 		{"30h", "30:00:00"},
+		{"-5s", "-0:00:05"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This fixes an error in which all week schedule timeslots would start
at midnight on January 1 1AD, and last for no seconds.
