### PR TITLE
Make myradio-go more mockable

### DIFF
--- a/api.go
+++ b/api.go
@@ -15,7 +15,7 @@ type apiRequester interface {
 	request(endpoint string, mixins []string, params map[string][]string) (*json.RawMessage, error)
 }
 
-// AuthedRequester answers API requests by making an authed API call.
+// authedRequester answers API requests by making an authed API call.
 type authedRequester struct {
 	apikey  string
 	baseurl url.URL

--- a/show_test.go
+++ b/show_test.go
@@ -1,8 +1,9 @@
-package myradio
+package myradio_test
 
 import (
 	"reflect"
 	"testing"
+	myradio "github.com/UniversityRadioYork/myradio-go"
 )
 
 const getSearchMetaJson = `
@@ -56,15 +57,15 @@ const getSearchMetaJson = `
 // TestGetSearchMetaUnmarshal tests the unmarshalling logic of GetSearchMeta.
 // It does not test the API endpoint.
 func TestGetSearchMetaUnmarshal(t *testing.T) {
-	expected := []ShowMeta{{
+	expected := []myradio.ShowMeta{{
 		ShowID:        8675309,
 		Title:         "Jenny I've Got Your Number",
 		CreditsString: "Tommy Tutone",
-		Credits: []Credit{
+		Credits: []myradio.Credit{
 			{
 				Type:     1,
 				MemberID: 666,
-				User: Member{
+				User: myradio.Member{
 					Memberid:     666,
 					Fname:        "Tommy",
 					Sname:        "Tutone",
@@ -76,25 +77,25 @@ func TestGetSearchMetaUnmarshal(t *testing.T) {
 		},
 		Description: "Tommy Tutone's got your number, and he's gotta make you his.",
 		ShowTypeID:  1,
-		Season: Link{
+		Season: myradio.Link{
 			Display: "season display",
 			Value:   "https://myradio.example.com/seasons/512",
 			Title:   "Seasons",
 			URL:     "https://myradio.example.com/seasons/512",
 		},
-		EditLink: Link{
+		EditLink: myradio.Link{
 			Display: "edit display",
 			Value:   "https://myradio.example.com/edit/8675309",
 			Title:   "Edit",
 			URL:     "https://myradio.example.com/edit/8675309",
 		},
-		ApplyLink: Link{
+		ApplyLink: myradio.Link{
 			Display: "apply display",
 			Value:   "https://myradio.example.com/apply/8675309",
 			Title:   "Apply",
 			URL:     "https://myradio.example.com/apply/8675309",
 		},
-		MicroSiteLink: Link{
+		MicroSiteLink: myradio.Link{
 			Display: "microsite display",
 			Value:   "https://myradio.example.com/microsites/8675309",
 			Title:   "Microsites",
@@ -103,7 +104,7 @@ func TestGetSearchMetaUnmarshal(t *testing.T) {
 		Photo: "https://myradio.example.com/photos/shows/8675309",
 	}}
 
-	session, err := MockSession([]byte(getSearchMetaJson))
+	session, err := myradio.MockSession([]byte(getSearchMetaJson))
 	if err != nil {
 		t.Error(err)
 	}

--- a/show_test.go
+++ b/show_test.go
@@ -1,0 +1,119 @@
+package myradio
+
+import (
+	"reflect"
+	"testing"
+)
+
+const getSearchMetaJson = `
+[{
+	"show_id": 8675309,
+	"title": "Jenny I've Got Your Number",
+	"credits_string": "Tommy Tutone",
+	"credits": [
+		{
+			"type": 1,
+			"memberid": 666,
+			"user": {
+				"memberid": 666,
+				"fname": "Tommy",
+				"sname": "Tutone",
+				"sex": "m",
+				"public_email": "tt500@example.com",
+				"receive_email": false
+			}
+		}
+	],
+	"description": "Tommy Tutone's got your number, and he's gotta make you his.",
+	"show_type_id": 1,
+	"seasons": {
+		"display": "season display",
+		"value": "https://myradio.example.com/seasons/512",
+		"title": "Seasons",
+		"url": "https://myradio.example.com/seasons/512"
+	},
+	"editlink": {
+		"display": "edit display",
+		"value": "https://myradio.example.com/edit/8675309",
+		"title": "Edit",
+		"url": "https://myradio.example.com/edit/8675309"
+	},
+	"applylink": {
+		"display": "apply display",
+		"value": "https://myradio.example.com/apply/8675309",
+		"title": "Apply",
+		"url": "https://myradio.example.com/apply/8675309"
+	},
+	"micrositelink": {
+		"display": "microsite display",
+		"value": "https://myradio.example.com/microsites/8675309",
+		"title": "Microsites",
+		"url": "https://myradio.example.com/microsites/8675309"
+	},
+	"photo": "https://myradio.example.com/photos/shows/8675309"
+}]`
+
+// TestGetSearchMetaUnmarshal tests the unmarshalling logic of GetSearchMeta.
+// It does not test the API endpoint.
+func TestGetSearchMetaUnmarshal(t *testing.T) {
+	expected := []ShowMeta{{
+		ShowID:        8675309,
+		Title:         "Jenny I've Got Your Number",
+		CreditsString: "Tommy Tutone",
+		Credits: []Credit{
+			{
+				Type:     1,
+				MemberID: 666,
+				User: Member{
+					Memberid:     666,
+					Fname:        "Tommy",
+					Sname:        "Tutone",
+					Sex:          "m",
+					Email:        "tt500@example.com",
+					Receiveemail: false,
+				},
+			},
+		},
+		Description: "Tommy Tutone's got your number, and he's gotta make you his.",
+		ShowTypeID:  1,
+		Season: Link{
+			Display: "season display",
+			Value:   "https://myradio.example.com/seasons/512",
+			Title:   "Seasons",
+			URL:     "https://myradio.example.com/seasons/512",
+		},
+		EditLink: Link{
+			Display: "edit display",
+			Value:   "https://myradio.example.com/edit/8675309",
+			Title:   "Edit",
+			URL:     "https://myradio.example.com/edit/8675309",
+		},
+		ApplyLink: Link{
+			Display: "apply display",
+			Value:   "https://myradio.example.com/apply/8675309",
+			Title:   "Apply",
+			URL:     "https://myradio.example.com/apply/8675309",
+		},
+		MicroSiteLink: Link{
+			Display: "microsite display",
+			Value:   "https://myradio.example.com/microsites/8675309",
+			Title:   "Microsites",
+			URL:     "https://myradio.example.com/microsites/8675309",
+		},
+		Photo: "https://myradio.example.com/photos/shows/8675309",
+	}}
+
+	session, err := MockSession([]byte(getSearchMetaJson))
+	if err != nil {
+		t.Error(err)
+	}
+
+	showMeta, err := session.GetSearchMeta("tutone")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(showMeta, expected) {
+		t.Errorf("expected:\n%v\n\ngot:\n%v", expected, showMeta)
+	}
+}


### PR DESCRIPTION
This PRQ:

- Splits `Session` into two things, a `Session` object that handles API requests from clients, and an `apiRequester` interface that actually does the API request;
- Moves the old `Session` behaviour into `authedRequester` (which implements `apiRequester`);
- Adds a new `mockRequester` that pretends to do an API request but instead returns a stock `json.RawMessage`;
- Allows `Session`s to be created with `mockRequesters` using the new `MockSession` constructor;
- Adds a (rather pointless) test to show how this can be used.

Thus, any of myradio-go's existing methods can now be sent a JSON file directly instead of having to make an API call, which makes testing the myradio-go specific logic much easier!

This might seem a little overengineered, but it's the easiest way I could think of to make this possible.

The reason `Session` still exists, instead of using `apiRequester` directly, is backwards compatibility; allowing the myradio-go API to remain method-based; allowing helper methods like `apiRequest` to be defined without changing the requesters; and allowing future expansion of what lives in `Session`.

Things that would be nice:
- Move `show_test`'s JSON into a separate file;
- Make it so myradio-go can dump out the JSON from calling an API method, so that it can be used for future testing.  This might be better done in an external shell script wrapping `curl` though.