### PR TITLE
🚿 Lint fixing and cleanup (⚠️ Possible untested breakages)

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -17,15 +17,7 @@ type Alias struct {
 // GetAllAliases retrieves all aliases in use.
 // It takes a list of additional MyRadio API mixins to use when retrieving the aliases.
 // This consumes one API request.
-func (s *Session) GetAllAliases(mixins []string) ([]Alias, error) {
-	data, err := s.apiRequest("/alias/allaliases", mixins)
-	if err != nil {
-		return nil, err
-	}
-	var aliases []Alias
-	err = json.Unmarshal(*data, &aliases)
-	if err != nil {
-		return nil, err
-	}
-	return aliases, nil
+func (s *Session) GetAllAliases(mixins []string) (aliases []Alias, err error) {
+	err = s.apiRequestInto(&aliases, "/alias/allaliases", mixins)
+	return
 }

--- a/api.go
+++ b/api.go
@@ -50,6 +50,9 @@ func (s *authedRequester) request(endpoint string, mixins []string, params map[s
 	}
 	client := &http.Client{}
 	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	if res.StatusCode != 200 {
 		return nil, fmt.Errorf(endpoint + fmt.Sprintf(" Not ok: HTTP %d", res.StatusCode))
 	}

--- a/api.go
+++ b/api.go
@@ -122,3 +122,13 @@ func (s *Session) apiRequestWithParams(endpoint string, mixins []string, params 
 func (s *Session) apiRequest(endpoint string, mixins []string) (*json.RawMessage, error) {
 	return s.apiRequestWithParams(endpoint, mixins, map[string][]string{})
 }
+
+// apiRequestInto conducts a GET request without custom parameters, and marshals the result directly into v.
+func (s *Session) apiRequestInto(v interface{}, endpoint string, mixins []string) error {
+	data, aerr := s.apiRequest(endpoint, mixins)
+	if aerr != nil {
+		return aerr
+	}
+
+	return json.Unmarshal(*data, v)
+}

--- a/banner.go
+++ b/banner.go
@@ -1,9 +1,5 @@
 package myradio
 
-import (
-	"encoding/json"
-)
-
 // Banner represents the key information about banners
 type Banner struct {
 	BannerID int    `json:"banner_id"`
@@ -15,10 +11,6 @@ type Banner struct {
 // GetLiveBanners gets the current live banners
 // and returns a slice of banners
 func (s *Session) GetLiveBanners() (banners []Banner, err error) {
-	data, err := s.apiRequest("/banner/livebanners/", []string{})
-	if err != nil {
-		return
-	}
-	err = json.Unmarshal(*data, &banners)
+	err = s.apiRequestInto(&banners, "/banner/livebanners/", []string{})
 	return
 }

--- a/lists.go
+++ b/lists.go
@@ -1,9 +1,6 @@
 package myradio
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "fmt"
 
 // List represents a mailing list.
 type List struct {
@@ -15,30 +12,14 @@ type List struct {
 
 // GetAllLists retrieves all mailing lists in the MyRadio system.
 // This consumes one API request.
-func (s *Session) GetAllLists() ([]List, error) {
-	data, err := s.apiRequest("/list/alllists", nil)
-	if err != nil {
-		return nil, err
-	}
-	var lists []List
-	err = json.Unmarshal(*data, &lists)
-	if err != nil {
-		return nil, err
-	}
-	return lists, nil
+func (s *Session) GetAllLists() (lists []List, err error) {
+	err = s.apiRequestInto(&lists, "/list/alllists", nil)
+	return
 }
 
 // GetUsers retrieves all users subscribed to a given mailing list.
 // This consumes one API request.
-func (s *Session) GetUsers(l *List) ([]User, error) {
-	data, err := s.apiRequest(fmt.Sprintf("/list/%d/members", l.Listid), []string{"personal_data"})
-	if err != nil {
-		return nil, err
-	}
-	var user []User
-	err = json.Unmarshal(*data, &user)
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
+func (s *Session) GetUsers(l *List) (users []User, err error) {
+	err = s.apiRequestInto(&users, fmt.Sprintf("/list/%d/members", l.Listid), []string{"personal_data"})
+	return
 }

--- a/officer.go
+++ b/officer.go
@@ -1,9 +1,6 @@
 package myradio
 
-import (
-	"encoding/json"
-	"time"
-)
+import "time"
 
 // OfficerPosition represents a specific station officer position.
 type OfficerPosition struct {
@@ -29,21 +26,17 @@ type OfficerPosition struct {
 // GetAllOfficerPositions retrieves all officer positions in MyRadio.
 // The amount of detail can be controlled by adding MyRadio mixins.
 // This consumes one API request.
-func (s *Session) GetAllOfficerPositions(mixins []string) ([]OfficerPosition, error) {
-	data, err := s.apiRequest("/officer/allofficerpositions", mixins)
-	if err != nil {
-		return nil, err
+func (s *Session) GetAllOfficerPositions(mixins []string) (positions []OfficerPosition, err error) {
+	if err = s.apiRequestInto(&positions, "/officer/allofficerpositions", mixins); err != nil {
+		return
 	}
-	var positions []OfficerPosition
-	err = json.Unmarshal(*data, &positions)
-	if err != nil {
-		return nil, err
-	}
+
 	for k, v := range positions {
 		for ik, iv := range v.History {
 			positions[k].History[ik].From = time.Unix(iv.FromRaw, 0)
 			positions[k].History[ik].To = time.Unix(iv.ToRaw, 0)
 		}
 	}
-	return positions, nil
+
+	return
 }

--- a/season.go
+++ b/season.go
@@ -71,18 +71,10 @@ func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
 	if err != nil {
 		return
 	}
-	for k, season := range seasons {
-		if season.isScheduled() {
-			seasons[k].FirstTime, err = time.Parse("02/01/2006 15:04", season.FirstTimeRaw)
-			if err != nil {
-				return
-			}
-		}
-		if season.isScheduled() {
-			seasons[k].Submitted, err = time.Parse("02/01/2006 15:04", season.SubmittedRaw)
-			if err != nil {
-				return
-			}
+	for k := range seasons {
+		err = seasons[k].populateTimes()
+		if err != nil {
+			return
 		}
 	}
 	return

--- a/season.go
+++ b/season.go
@@ -61,7 +61,7 @@ func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error
 }
 
 // GetAllSeasonsInLatestTerm gets all seasons in the most recent term.
-// It consumes one API request.
+// This consumes one API request.
 func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
 	data, err := s.apiRequest("/season/allseasonsinlatestterm/", []string{})
 	if err != nil {

--- a/season.go
+++ b/season.go
@@ -1,7 +1,6 @@
 package myradio
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -36,6 +35,7 @@ func (s *Season) populateSeasonTimes() (err error) {
 			return
 		}
 	}
+
 	s.Submitted, err = parseShortTime(s.SubmittedRaw)
 	return
 }
@@ -43,54 +43,45 @@ func (s *Season) populateSeasonTimes() (err error) {
 // GetSeason retrieves the season with the given ID.
 // This consumes one API request.
 func (s *Session) GetSeason(id int) (season Season, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/season/%d/", id), []string{})
-	if err != nil {
+	if err = s.apiRequestInto(&season, fmt.Sprintf("/season/%d/", id), []string{}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &season)
-	if err != nil {
-		return
-	}
+
 	err = season.populateSeasonTimes()
+
 	return
 }
 
 // GetTimeslotsForSeason retrieves all timeslots for the season with the given ID.
 // This consumes one API request.
 func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/season/%d/alltimeslots/", id), []string{})
-	if err != nil {
+	if err = s.apiRequestInto(&timeslots, fmt.Sprintf("/season/%d/alltimeslots/", id), []string{}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &timeslots)
-	if err != nil {
-		return
-	}
+
 	for k := range timeslots {
 		err = timeslots[k].populateTimeslotTimes()
 		if err != nil {
 			return
 		}
 	}
+
 	return
 }
 
 // GetAllSeasonsInLatestTerm gets all seasons in the most recent term.
 // This consumes one API request.
 func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
-	data, err := s.apiRequest("/season/allseasonsinlatestterm/", []string{})
-	if err != nil {
+	if err = s.apiRequestInto(&seasons, "/season/allseasonsinlatestterm/", []string{}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &seasons)
-	if err != nil {
-		return
-	}
+
 	for k := range seasons {
 		err = seasons[k].populateSeasonTimes()
 		if err != nil {
 			return
 		}
 	}
+
 	return
 }

--- a/season.go
+++ b/season.go
@@ -3,7 +3,6 @@ package myradio
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 // GetSeason retrieves the season with the given ID.
@@ -17,11 +16,7 @@ func (s *Session) GetSeason(id int) (season Season, err error) {
 	if err != nil {
 		return
 	}
-	season.FirstTime, err = time.Parse("02/01/2006 15:04", season.FirstTimeRaw)
-	if err != nil {
-		return
-	}
-	season.Submitted, err = time.Parse("02/01/2006 15:04", season.SubmittedRaw)
+	err = season.populateSeasonTimes()
 	return
 }
 
@@ -30,29 +25,14 @@ func (s *Session) GetSeason(id int) (season Season, err error) {
 func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error) {
 	data, err := s.apiRequest(fmt.Sprintf("/season/%d/alltimeslots/", id), []string{})
 	if err != nil {
-		return nil, err
+		return
 	}
 	err = json.Unmarshal(*data, &timeslots)
 	if err != nil {
-		return nil, err
+		return
 	}
-	for k, v := range timeslots {
-		timeslots[k].Time = time.Unix(v.TimeRaw, 0)
-		if v.FirstTimeRaw != "Not Scheduled" {
-			timeslots[k].FirstTime, err = time.Parse("02/01/2006 15:04", v.FirstTimeRaw)
-			if err != nil {
-				return
-			}
-		}
-		timeslots[k].Submitted, err = time.Parse("02/01/2006 15:04", v.SubmittedRaw)
-		if err != nil {
-			return
-		}
-		timeslots[k].StartTime, err = time.Parse("02/01/2006 15:04", v.StartTimeRaw)
-		if err != nil {
-			return
-		}
-		timeslots[k].Duration, err = parseDuration(v.DurationRaw)
+	for k := range timeslots {
+		err = timeslots[k].populateTimeslotTimes()
 		if err != nil {
 			return
 		}
@@ -72,7 +52,7 @@ func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
 		return
 	}
 	for k := range seasons {
-		err = seasons[k].populateTimes()
+		err = seasons[k].populateSeasonTimes()
 		if err != nil {
 			return
 		}

--- a/season.go
+++ b/season.go
@@ -60,6 +60,8 @@ func (s *Session) GetTimeslotsForSeason(id int) (timeslots []Timeslot, err error
 	return
 }
 
+// GetAllSeasonsInLatestTerm gets all seasons in the most recent term.
+// It consumes one API request.
 func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
 	data, err := s.apiRequest("/season/allseasonsinlatestterm/", []string{})
 	if err != nil {

--- a/season.go
+++ b/season.go
@@ -3,7 +3,42 @@ package myradio
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
+
+// Season represents a season in the MyRadio schedule.
+// A MyRadio season contains timeslots.
+type Season struct {
+	ShowMeta
+	SeasonID      int    `json:"season_id"`
+	SeasonNum     int    `json:"season_num"`
+	SubmittedRaw  string `json:"submitted"`
+	Submitted     time.Time
+	RequestedTime string `json:"requested_time"`
+	FirstTimeRaw  string `json:"first_time"`
+	FirstTime     time.Time
+	NumEpisodes   Link `json:"num_episodes"`
+	AllocateLink  Link `json:"allocatelink"`
+	RejectLink    Link `json:"rejectlink"`
+}
+
+// isScheduled returns whether the Season has been scheduled.
+// This consumes no API requests.
+func (s *Season) isScheduled() bool {
+	return s.FirstTimeRaw != "Not Scheduled"
+}
+
+// populateSeasonTimes sets the times for the given Season given their raw values.
+func (s *Season) populateSeasonTimes() (err error) {
+	if s.isScheduled() {
+		s.FirstTime, err = parseShortTime(s.FirstTimeRaw)
+		if err != nil {
+			return
+		}
+	}
+	s.Submitted, err = parseShortTime(s.SubmittedRaw)
+	return
+}
 
 // GetSeason retrieves the season with the given ID.
 // This consumes one API request.

--- a/season.go
+++ b/season.go
@@ -72,13 +72,13 @@ func (s *Session) GetAllSeasonsInLatestTerm() (seasons []Season, err error) {
 		return
 	}
 	for k, season := range seasons {
-		if season.FirstTimeRaw != "Not Scheduled" {
+		if season.isScheduled() {
 			seasons[k].FirstTime, err = time.Parse("02/01/2006 15:04", season.FirstTimeRaw)
 			if err != nil {
 				return
 			}
 		}
-		if season.FirstTimeRaw != "Not Scheduled" {
+		if season.isScheduled() {
 			seasons[k].Submitted, err = time.Parse("02/01/2006 15:04", season.SubmittedRaw)
 			if err != nil {
 				return

--- a/show.go
+++ b/show.go
@@ -1,7 +1,6 @@
 package myradio
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 )
@@ -40,56 +39,33 @@ type Link struct {
 
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.
 // This consumes one API request.
-func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
+func (s *Session) GetSearchMeta(term string) (shows []ShowMeta, err error) {
 	q := url.QueryEscape(term)
 
-	data, err := s.apiRequest(fmt.Sprintf("/show/searchmeta/%s", q), []string{})
-	if err != nil {
-		return nil, err
-	}
-
-	var shows []ShowMeta
-	err = json.Unmarshal(*data, &shows)
-	if err != nil {
-		return nil, err
-	}
-
-	return shows, nil
+	err = s.apiRequestInto(&shows, fmt.Sprintf("/show/searchmeta/%s", q), []string{})
+	return
 }
 
 // GetShow retrieves the show with the given ID.
 // This consumes one API request.
-func (s *Session) GetShow(id int) (*ShowMeta, error) {
-	data, err := s.apiRequest(fmt.Sprintf("/show/%d", id), []string{})
-	if err != nil {
-		return nil, err
-	}
-
-	var show ShowMeta
-	err = json.Unmarshal(*data, &show)
-	if err != nil {
-		return nil, err
-	}
-
-	return &show, nil
+func (s *Session) GetShow(id int) (show *ShowMeta, err error) {
+	err = s.apiRequestInto(&show, fmt.Sprintf("/show/%d", id), []string{})
+	return
 }
 
 // GetSeasons retrieves the seasons of the show with the given ID.
 // This consumes one API request.
 func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/show/%d/allseasons", id), []string{})
-	if err != nil {
+	if err = s.apiRequestInto(&seasons, fmt.Sprintf("/show/%d/allseasons", id), []string{}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &seasons)
-	if err != nil {
-		return
-	}
+
 	for i := range seasons {
 		err = seasons[i].populateSeasonTimes()
 		if err != nil {
 			return
 		}
 	}
+
 	return
 }

--- a/show.go
+++ b/show.go
@@ -61,15 +61,15 @@ func (s *Season) isScheduled() bool {
 	return s.FirstTimeRaw != "Not Scheduled"
 }
 
-// populateTimes sets the times for the given Season given their raw values.
-func (s *Season) populateTimes() (err error) {
+// populateSeasonTimes sets the times for the given Season given their raw values.
+func (s *Season) populateSeasonTimes() (err error) {
 	if s.isScheduled() {
-		s.FirstTime, err = time.Parse("02/01/2006 15:04", s.FirstTimeRaw)
+		s.FirstTime, err = parseShortTime(s.FirstTimeRaw)
 		if err != nil {
 			return
 		}
 	}
-	s.Submitted, err = time.Parse("02/01/2006 15:04", s.SubmittedRaw)
+	s.Submitted, err = parseShortTime(s.SubmittedRaw)
 	return
 }
 
@@ -131,7 +131,7 @@ func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
 		return
 	}
 	for i := range seasons {
-		err = seasons[i].populateTimes()
+		err = seasons[i].populateSeasonTimes()
 		if err != nil {
 			return
 		}

--- a/show.go
+++ b/show.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // Credit represents a show credit associating a user with a show.
@@ -37,40 +36,6 @@ type Link struct {
 	Value   interface{} `json:"value"`
 	Title   string      `json:"title,omitempty"`
 	URL     string      `json:"url"`
-}
-
-// Season represents a season in the MyRadio schedule.
-// A MyRadio season contains timeslots.
-type Season struct {
-	ShowMeta
-	SeasonID      int    `json:"season_id"`
-	SeasonNum     int    `json:"season_num"`
-	SubmittedRaw  string `json:"submitted"`
-	Submitted     time.Time
-	RequestedTime string `json:"requested_time"`
-	FirstTimeRaw  string `json:"first_time"`
-	FirstTime     time.Time
-	NumEpisodes   Link `json:"num_episodes"`
-	AllocateLink  Link `json:"allocatelink"`
-	RejectLink    Link `json:"rejectlink"`
-}
-
-// isScheduled returns whether the Season has been scheduled.
-// This consumes no API requests.
-func (s *Season) isScheduled() bool {
-	return s.FirstTimeRaw != "Not Scheduled"
-}
-
-// populateSeasonTimes sets the times for the given Season given their raw values.
-func (s *Season) populateSeasonTimes() (err error) {
-	if s.isScheduled() {
-		s.FirstTime, err = parseShortTime(s.FirstTimeRaw)
-		if err != nil {
-			return
-		}
-	}
-	s.Submitted, err = parseShortTime(s.SubmittedRaw)
-	return
 }
 
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.

--- a/show.go
+++ b/show.go
@@ -61,6 +61,18 @@ func (s *Season) isScheduled() bool {
 	return s.FirstTimeRaw != "Not Scheduled"
 }
 
+// populateTimes sets the times for the given Season given their raw values.
+func (s *Season) populateTimes() (err error) {
+	if s.isScheduled() {
+		s.FirstTime, err = time.Parse("02/01/2006 15:04", s.FirstTimeRaw)
+		if err != nil {
+			return
+		}
+	}
+	s.Submitted, err = time.Parse("02/01/2006 15:04", s.SubmittedRaw)
+	return
+}
+
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.
 // This consumes one API request.
 func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
@@ -118,14 +130,8 @@ func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
 	if err != nil {
 		return
 	}
-	for k, v := range seasons {
-		if v.isScheduled() {
-			seasons[k].FirstTime, err = time.Parse("02/01/2006 15:04", v.FirstTimeRaw)
-			if err != nil {
-				return
-			}
-		}
-		seasons[k].Submitted, err = time.Parse("02/01/2006 15:04", v.SubmittedRaw)
+	for i := range seasons {
+		err = seasons[i].populateTimes()
 		if err != nil {
 			return
 		}

--- a/show.go
+++ b/show.go
@@ -55,6 +55,12 @@ type Season struct {
 	RejectLink    Link `json:"rejectlink"`
 }
 
+// isScheduled returns whether the Season has been scheduled.
+// This consumes no API requests.
+func (s *Season) isScheduled() bool {
+	return s.FirstTimeRaw != "Not Scheduled"
+}
+
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.
 // This consumes one API request.
 func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
@@ -113,7 +119,7 @@ func (s *Session) GetSeasons(id int) (seasons []Season, err error) {
 		return
 	}
 	for k, v := range seasons {
-		if v.FirstTimeRaw != "Not Scheduled" {
+		if v.isScheduled() {
 			seasons[k].FirstTime, err = time.Parse("02/01/2006 15:04", v.FirstTimeRaw)
 			if err != nil {
 				return

--- a/show.go
+++ b/show.go
@@ -41,47 +41,37 @@ type Link struct {
 // GetSearchMeta retrieves all shows whose metadata matches a given search term.
 // This consumes one API request.
 func (s *Session) GetSearchMeta(term string) ([]ShowMeta, error) {
-
 	q := url.QueryEscape(term)
 
 	data, err := s.apiRequest(fmt.Sprintf("/show/searchmeta/%s", q), []string{})
-
 	if err != nil {
 		return nil, err
 	}
 
 	var shows []ShowMeta
-
 	err = json.Unmarshal(*data, &shows)
-
 	if err != nil {
 		return nil, err
 	}
 
 	return shows, nil
-
 }
 
 // GetShow retrieves the show with the given ID.
 // This consumes one API request.
 func (s *Session) GetShow(id int) (*ShowMeta, error) {
-
 	data, err := s.apiRequest(fmt.Sprintf("/show/%d", id), []string{})
-
 	if err != nil {
 		return nil, err
 	}
 
 	var show ShowMeta
-
 	err = json.Unmarshal(*data, &show)
-
 	if err != nil {
 		return nil, err
 	}
 
 	return &show, nil
-
 }
 
 // GetSeasons retrieves the seasons of the show with the given ID.

--- a/team.go
+++ b/team.go
@@ -1,7 +1,6 @@
 package myradio
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -49,31 +48,21 @@ type HeadPosition struct {
 // GetCurrentTeams retrieves all teams inside the station committee.
 // This consumes one API request.
 func (s *Session) GetCurrentTeams() (teams []Team, err error) {
-	data, err := s.apiRequest("/team/currentteams/", []string{})
-	if err != nil {
-		return
-	}
-	err = json.Unmarshal(*data, &teams)
-	if err != nil {
-		return
-	}
+	err = s.apiRequestInto(&teams, "/team/currentteams/", []string{})
 	return
 }
 
 // GetTeamWithOfficers retrieves a team record with officer information for the given team name.
 // This consumes one API request.
 func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/team/byalias/%s", teamName), []string{"officers"})
-	if err != nil {
+	if err = s.apiRequestInto(&team, fmt.Sprintf("/team/byalias/%s", teamName), []string{"officers"}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &team)
-	if err != nil {
-		return
-	}
+
 	for k, v := range team.Officers {
 		team.Officers[k].From = time.Unix(v.FromRaw, 0)
 	}
+
 	return
 }
 
@@ -81,14 +70,10 @@ func (s *Session) GetTeamWithOfficers(teamName string) (team Team, err error) {
 // The amount of detail can be controlled using MyRadio mixins.
 // This consumes one API request.
 func (s *Session) GetTeamHeadPositions(id int, mixins []string) (head []HeadPosition, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/team/%d/headpositions", id), mixins)
-	if err != nil {
+	if err = s.apiRequestInto(&head, fmt.Sprintf("/team/%d/headpositions", id), mixins); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &head)
-	if err != nil {
-		return
-	}
+
 	for k, v := range head {
 		if v.Position.History != nil {
 			for ik, iv := range v.Position.History {
@@ -97,5 +82,6 @@ func (s *Session) GetTeamHeadPositions(id int, mixins []string) (head []HeadPosi
 			}
 		}
 	}
+
 	return
 }

--- a/timeslot.go
+++ b/timeslot.go
@@ -82,7 +82,7 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 
 // populateTimes fills in the cooked times in a MyRadio timeslot from their raw equivalents.
 func populateTimes(timeslot *Timeslot) error {
-	var err error = nil
+	var err error
 	timeslot.Time = time.Unix(timeslot.TimeRaw, 0)
 
 	// MyRadio returns local timestamps, not UTC.
@@ -99,11 +99,7 @@ func populateTimes(timeslot *Timeslot) error {
 		return err
 	}
 	timeslot.Duration, err = parseDuration(timeslot.DurationRaw)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // GetWeekSchedule gets the weekly schedule for ISO 8601 week week of year year.

--- a/timeslot.go
+++ b/timeslot.go
@@ -90,16 +90,11 @@ type TracklistItem struct {
 // GetCurrentAndNext gets the current and next shows at the time of the call.
 // This consumes one API request.
 func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
-	data, aerr := s.apiRequest("/timeslot/currentandnext", []string{})
-	if aerr != nil {
-		return nil, aerr
-	}
-
 	var currentAndNext CurrentAndNext
-	if err := json.Unmarshal(*data, &currentAndNext); err != nil {
+	if err := s.apiRequestInto(&currentAndNext, "/timeslot/currentandnext", []string{}); err != nil {
 		return nil, err
 	}
-	
+
 	if err := currentAndNext.Current.populateShowTimes(); err != nil {
 		return nil, err
 	}
@@ -206,15 +201,9 @@ func destringTimeslots(stringyTimeslots map[string][]Timeslot) (map[int][]Timesl
 // GetTimeslot retrieves the timeslot with the given ID.
 // This consumes one API request.
 func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
-	var data *json.RawMessage
-	if data, err = s.apiRequest(fmt.Sprintf("/timeslot/%d", id), []string{}); err != nil {
+	if err = s.apiRequestInto(&timeslot, fmt.Sprintf("/timeslot/%d", id), []string{}); err != nil {
 		return
 	}
-
-	if err = json.Unmarshal(*data, &timeslot); err != nil {
-		return
-	}
-
 	err = timeslot.populateTimeslotTimes()
 	return
 }
@@ -222,11 +211,9 @@ func (s *Session) GetTimeslot(id int) (timeslot Timeslot, err error) {
 // GetTrackListForTimeslot retrieves the tracklist for the timeslot with the given ID.
 // This consumes one API request.
 func (s *Session) GetTrackListForTimeslot(id int) (tracklist []TracklistItem, err error) {
-	data, err := s.apiRequest(fmt.Sprintf("/tracklistItem/tracklistfortimeslot/%d", id), []string{})
-	if err != nil {
+	if err = s.apiRequestInto(&tracklist, fmt.Sprintf("/tracklistItem/tracklistfortimeslot/%d", id), []string{}); err != nil {
 		return
 	}
-	err = json.Unmarshal(*data, &tracklist)
 	for k, v := range tracklist {
 		tracklist[k].Time = time.Unix(tracklist[k].TimeRaw, 0)
 		tracklist[k].StartTime, err = time.Parse("02/01/2006 15:04:05", v.StartTimeRaw)

--- a/timeslot.go
+++ b/timeslot.go
@@ -27,6 +27,19 @@ type Show struct {
 	Id           uint64 `json:"id,omitempty"`
 }
 
+// populateShowTimes sets the times for the given Show given their raw values.
+func (s *Show) populateShowTimes() error {
+	s.StartTime = time.Unix(s.StartTimeRaw, 0)
+
+	timeint, err := strconv.ParseInt(s.EndTimeRaw, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	s.EndTime = time.Unix(timeint, 0)
+	return nil
+}
+
 // Timeslot contains information about a single timeslot in the URY schedule.
 // A timeslot is a single slice of time on the schedule, typically one hour long.
 type Timeslot struct {
@@ -88,14 +101,16 @@ func (s *Session) GetCurrentAndNext() (*CurrentAndNext, error) {
 	if err != nil {
 		return nil, err
 	}
-	currentAndNext.Current.StartTime = time.Unix(currentAndNext.Current.StartTimeRaw, 0)
-	if timeint, err := strconv.ParseInt(currentAndNext.Current.EndTimeRaw, 10, 64); err != nil {
-		currentAndNext.Current.EndTime = time.Unix(timeint, 0)
+	
+	err = currentAndNext.Current.populateShowTimes()
+	if err != nil {
+		return nil, err
 	}
-	currentAndNext.Next.StartTime = time.Unix(currentAndNext.Next.StartTimeRaw, 0)
-	if timeint, err := strconv.ParseInt(currentAndNext.Next.EndTimeRaw, 10, 64); err != nil {
-		currentAndNext.Next.EndTime = time.Unix(timeint, 0)
+	err = currentAndNext.Next.populateShowTimes()
+	if err != nil {
+		return nil, err
 	}
+
 	return &currentAndNext, nil
 }
 

--- a/timeslot.go
+++ b/timeslot.go
@@ -147,7 +147,7 @@ func (s *Session) GetWeekSchedule(year, week int) (map[int][]Timeslot, error) {
 }
 
 // isEmptySchedule tries to work out, from MyRadio schedule JSON, whether the schedule is empty.
-func isEmptySchedule(data *json.RawMessage) bool {
+func isEmptySchedule(data json.Marshaler) bool {
 	bs, err := data.MarshalJSON()
 	if err != nil {
 		// The logic later on in GetWeekSchedule should hit this same error, so handle it there.

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -6,18 +6,9 @@ import (
 	"testing"
 )
 
-// TestGetWeekScheduleZeroArray tests whether GetWeekSchedule handles [] correctly.
-func TestGetWeekScheduleZeroArray(t *testing.T) {
-	testGetWeekScheduleZero(t, []byte("[]"))
-}
-
-// TestGetWeekScheduleZeroObject tests whether GetWeekSchedule handles {} correctly.
-func TestGetWeekScheduleZeroObject(t *testing.T) {
-	testGetWeekScheduleZero(t, []byte("{}"))
-}
 
 // testGetWeekScheduleZero tests whether GetWeekSchedule handles empty schedules correctly.
-func testGetWeekScheduleZero(t *testing.T, zero []byte) {
+func testGetWeekScheduleZero(t *testing.T) {
 	expected := map[int][]myradio.Timeslot{
 		1: {},
 		2: {},
@@ -28,17 +19,20 @@ func testGetWeekScheduleZero(t *testing.T, zero []byte) {
 		7: {},
 	}
 
-	session, err := myradio.MockSession(zero)
-	if err != nil {
-		t.Error(err)
-	}
+	zeroes := [][]byte{ []byte("[]"), []byte("{}") }
+	for _, zero := range zeroes{
+		session, err := myradio.MockSession(zero)
+		if err != nil {
+			t.Error(err)
+		}
 
-	schedule, err := session.GetWeekSchedule(0, 1)
-	if err != nil {
-		t.Error(err)
-	}
+		schedule, err := session.GetWeekSchedule(0, 1)
+		if err != nil {
+			t.Error(err)
+		}
 
-	if !reflect.DeepEqual(schedule, expected) {
-		t.Errorf("expected:\n%v\n\ngot:\n%v", expected, schedule)
+		if !reflect.DeepEqual(schedule, expected) {
+			t.Error("expected:", expected, "got:", schedule)
+		}
 	}
 }

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -18,12 +18,12 @@ func testCanEntryZero(t *testing.T) {
 
 // testCanEntryEnds tests whether a CurrentAndNext entry returns something sensible for Ends.
 func testCanEntryEnds(t *testing.T) {
-	cases := []struct{
+	cases := []struct {
 		t time.Time
 		e bool
 	}{
-		{ t: time.Time{}, e: false },
-		{ t: time.Date(2009, time.April, 13, 11, 11, 11, 0, time.UTC), e: true },
+		{t: time.Time{}, e: false},
+		{t: time.Date(2009, time.April, 13, 11, 11, 11, 0, time.UTC), e: true},
 	}
 
 	for _, c := range cases {
@@ -47,8 +47,8 @@ func testGetWeekScheduleZero(t *testing.T) {
 		7: {},
 	}
 
-	zeroes := [][]byte{ []byte("[]"), []byte("{}") }
-	for _, zero := range zeroes{
+	zeroes := [][]byte{[]byte("[]"), []byte("{}")}
+	for _, zero := range zeroes {
 		session, err := myradio.MockSession(zero)
 		if err != nil {
 			t.Error(err)

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -18,7 +18,7 @@ func TestGetWeekScheduleZeroObject(t *testing.T) {
 
 // testGetWeekScheduleZero tests whether GetWeekSchedule handles empty schedules correctly.
 func testGetWeekScheduleZero(t *testing.T, zero []byte) {
-	expected := map[int][]myradio.Timeslot {
+	expected := map[int][]myradio.Timeslot{
 		1: {},
 		2: {},
 		3: {},

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -4,8 +4,36 @@ import (
 	myradio "github.com/UniversityRadioYork/myradio-go"
 	"reflect"
 	"testing"
+	"time"
 )
 
+// testCanEntryZero tests whether a zero-valued CurrentAndNext entry returns true for IsZero.
+// It does NOT (yet) test the converse.
+func testCanEntryZero(t *testing.T) {
+	s := myradio.Show{}
+	if !s.IsZero() {
+		t.Error("zero show returns false for IsZero")
+	}
+}
+
+// testCanEntryEnds tests whether a CurrentAndNext entry returns something sensible for Ends.
+func testCanEntryEnds(t *testing.T) {
+	cases := []struct{
+		t time.Time
+		e bool
+	}{
+		{ t: time.Time{}, e: false },
+		{ t: time.Date(2009, time.April, 13, 11, 11, 11, 0, time.UTC), e: true },
+	}
+
+	for _, c := range cases {
+		s := myradio.Show{}
+		s.EndTime = c.t
+		if s.Ends() != c.e {
+			t.Error("show with end time", c.t, "gave incorrect Ends() of", s.Ends())
+		}
+	}
+}
 
 // testGetWeekScheduleZero tests whether GetWeekSchedule handles empty schedules correctly.
 func testGetWeekScheduleZero(t *testing.T) {

--- a/tracks.go
+++ b/tracks.go
@@ -1,7 +1,6 @@
 package myradio
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -114,45 +113,21 @@ func (t *Track) IntroUsec() uint64 {
 // GetTrack tries to get the Track with the given ID.
 // Track IDs are unique, so we do not need the record ID.
 // This consumes one API request.
-func (s *Session) GetTrack(trackid uint64) (*Track, error) {
-	data, err := s.apiRequest(fmt.Sprintf("/track/%d", trackid), nil)
-	if err != nil {
-		return nil, err
-	}
-	track := new(Track)
-	err = json.Unmarshal(*data, track)
-	if err != nil {
-		return nil, err
-	}
-	return track, nil
+func (s *Session) GetTrack(trackid uint64) (track *Track, err error) {
+	err = s.apiRequestInto(&track, fmt.Sprintf("/track/%d", trackid), nil)
+	return
 }
 
 // GetTrackTitle tries to get the title of the track with the given ID.
 // This consumes one API request.
-func (s *Session) GetTrackTitle(trackid uint64) (string, error) {
-	data, err := s.apiRequest(fmt.Sprintf("/track/%d/title", trackid), nil)
-	if err != nil {
-		return "", err
-	}
-	var title string
-	err = json.Unmarshal(*data, &title)
-	if err != nil {
-		return "", err
-	}
-	return title, nil
+func (s *Session) GetTrackTitle(trackid uint64) (title string, err error) {
+	err = s.apiRequestInto(&title, fmt.Sprintf("/track/%d/title", trackid), nil)
+	return
 }
 
 // GetTrackAlbum tries to get the Album of the track with the given ID.
 // This consumes one API request.
-func (s *Session) GetTrackAlbum(trackid uint64) (*Album, error) {
-	data, err := s.apiRequest(fmt.Sprintf("/track/%d/album", trackid), nil)
-	if err != nil {
-		return nil, err
-	}
-	album := new(Album)
-	err = json.Unmarshal(*data, album)
-	if err != nil {
-		return nil, err
-	}
-	return album, nil
+func (s *Session) GetTrackAlbum(trackid uint64) (album *Album, err error) {
+	err = s.apiRequestInto(&album, fmt.Sprintf("/track/%d/album", trackid), nil)
+	return
 }

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package myradio
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -24,6 +25,11 @@ func parseDuration(value string) (dur time.Duration, err error) {
 	// However, while convenient, this fails for durations that don't 'look' like times,
 	// eg. anything over 23:59:60.
 
+	if len(value) == 0 {
+		err = errors.New("parseDuration: duration string empty")
+		return
+	}
+
 	vs := strings.Split(value, ":")
 	if len(vs) != 3 {
 		err = fmt.Errorf("parseDuration: '%s' has %d sections but should have 3", value, len(vs))
@@ -40,6 +46,7 @@ func parseDuration(value string) (dur time.Duration, err error) {
 
 	// Save us from repeating the same processing logic 3 times, at the cost of some efficiency when we fail.
 	parseBit := func(bit string, min, max int64) (val int64) {
+		// Short-circuit if previous parseBits failed.
 		if err != nil {
 			return
 		}

--- a/utils.go
+++ b/utils.go
@@ -26,7 +26,7 @@ func parseDuration(value string) (dur time.Duration, err error) {
 
 	vs := strings.Split(value, ":")
 	if len(vs) != 3 {
-		err = fmt.Errorf("parseDuration: '%s' has %i sections but should have 3", value, len(vs))
+		err = fmt.Errorf("parseDuration: '%s' has %d sections but should have 3", value, len(vs))
 		return
 	}
 
@@ -50,7 +50,7 @@ func parseDuration(value string) (dur time.Duration, err error) {
 
 		// At this stage, val will contain the parsed value: this is just an additional sanity check.
 		if val < min || max < val {
-			err = fmt.Errorf("parseDuration: expected %i-%i, got %i", min, max, val)
+			err = fmt.Errorf("parseDuration: expected %d-%d, got %d", min, max, val)
 		}
 
 		return

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// parseShortTime parses times in MyRadio's 'DD/MM/YYYY HH:MM' local-time format.
+// On success, it returns the equivalent time; else, it reports an error.
+func parseShortTime(value string) (time.Time, error) {
+	return time.ParseInLocation("02/01/2006 15:04", value, time.Local)
+}
+
 // parseDuration parses durations in MyRadio's 'HH:MM:SS' format.
 // On success, it returns the equivalent duration; else, it reports an error.
 // Errors occur if the duration is not in the given format, or cannot be represented as a Duration.

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,6 +5,32 @@ import (
 	"time"
 )
 
+func TestParseShortTime(t *testing.T) {
+	tests := []struct {
+		expected time.Time
+		time     string
+	}{
+		{
+			time.Date(1970, time.January, 1, 0, 0, 0, 0, time.Local),
+			"01/01/1970 00:00",
+		},
+		{
+			time.Date(2009, time.April, 13, 11, 11, 0, 0, time.Local),
+			"13/04/2009 11:11",
+		},
+	}
+
+	for _, test := range tests {
+		got, err := parseShortTime(test.time)
+		if err != nil {
+			t.Error("unexpected error:", err)
+		}
+		if !got.Equal(test.expected) {
+			t.Error("expected:", test.expected, "got:", got)
+		}
+	}
+}
+
 func TestParseDuration(t *testing.T) {
 	tests := []struct {
 		expectedStr string
@@ -20,8 +46,36 @@ func TestParseDuration(t *testing.T) {
 		// We can safely leave testing the time lib to the stl
 		expected, _ := time.ParseDuration(test.expectedStr)
 		got, err := parseDuration(test.time)
-		if err != nil || got != expected {
-			t.Error("Got:", got, ", Expected:", expected, ", Error:", err)
+		if err != nil {
+			t.Error("unexpected error:", err)
+		}
+		if got != expected {
+			t.Error("expected:", expected, "got:", got)
+		}
+	}
+}
+
+func TestParseDurationError(t *testing.T) {
+	tests := []struct {
+		errStr string
+		time   string
+	}{
+		{"parseDuration: duration string empty", ""},
+		{"parseDuration: '01' has 1 sections but should have 3", "01"},
+		{"parseDuration: '02:05' has 2 sections but should have 3", "02:05"},
+		{"parseDuration: '01:02:03:04' has 4 sections but should have 3", "01:02:03:04"},
+		{"parseDuration: expected 0-59, got -1", "10:-1:00"},
+		{"parseDuration: expected 0-59, got 60", "10:10:60"},
+		{`strconv.ParseInt: parsing "a": invalid syntax`, "a:b:c"},
+	}
+
+	for _, test := range tests {
+		_, err := parseDuration(test.time)
+		if err == nil {
+			t.Error("no error, was expecting one")
+		}
+		if err.Error() != test.errStr {
+			t.Error("expected:", test.errStr, "got:", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
**NOTE:** This PRQ aggressively collapses a lot of seemingly duplicated code for season and time slot time processing.  Some of this code was subtly different across the board, and I made the assumption that this was because some of the code was slightly buggy.  **Please check to make sure I haven't accidentally tagged MyRadio API inconsistencies as `myradio-go` bugs.**

**NOTE:** I'm assuming here that all MyRadio timestamps are in local time.  Again, check that this is correct.  I might have introduced bugs where I thought I was removing them!

This PRQ does a non-exhaustive lint of the code so far for `myradio-go` using `gometalinter`, as well as some other stylistic improvements.  It:

- Fixes a missing error handle in `api.go`;
- Collapses a lot of seemingly similar season and timeslot time handling logic into a pair of methods on seasons and timeslots (⚠️ see warning above);
- Removes some unnecessary vertical whitespace here and there;
- Removes some unnecessary control flow here and there;
- Moves the season structures from `show.go` to `season.go`.

**NEW 29/03**:

- Added `apiRequestInto` function that rolls up `apiRequest` and `json.Unmarshal`: massive simplifications to pretty much every API function;
- Shaved a few lines by bundling up `err`s into if statements where possible (controversial?);
- Factored out a bit more duplicated code.

It **does not**:

- Rename any fields (because this would break users).  There are a few suggested field renames that I think we should do, but need some coordination:
  - alias.go:9:2 , Id should be ID (golint)
  - timeslot.go:26:2, Url should be URL (golint)
  - timeslot.go:27:2, Id should be ID (golint)
  - user.go:21:2, OfficerId should be OfficerID (golint)
  - user.go:23:2, TeamId should be TeamID (golint)
  - user.go:32:2, PhotoId should be PhotoID (golint)
  - user.go:37:2, struct field Url should be URL (golint)
- Fix a missing error handle with the `defer` in `api.go`, as this seems like it'd be difficult to do properly;
- Rename `ShowMeta` (should be eg. `Show`), or `GetSeasons` (should be eg. `GetSeasonsForShow`), because these need some design and might break users;
- Add any new tests.