### PR TITLE
Moving show subtypes into MyRadio, part 4 - API in myradio-go

### DIFF
--- a/season.go
+++ b/season.go
@@ -13,9 +13,10 @@ type Season struct {
 	RequestedTime string `json:"requested_time"`
 	FirstTimeRaw  string `json:"first_time"`
 	FirstTime     time.Time
-	NumEpisodes   Link `json:"num_episodes"`
-	AllocateLink  Link `json:"allocatelink"`
-	RejectLink    Link `json:"rejectlink"`
+	NumEpisodes   Link              `json:"num_episodes"`
+	AllocateLink  Link              `json:"allocatelink"`
+	RejectLink    Link              `json:"rejectlink"`
+	Subtype       ShowSeasonSubtype `json:"subtype"`
 }
 
 // isScheduled returns whether the Season has been scheduled.

--- a/show.go
+++ b/show.go
@@ -15,17 +15,18 @@ type Credit struct {
 // A MyRadio show contains seasons, each containing timeslots.
 // @TODO: Refactor this to something better named
 type ShowMeta struct {
-	ShowID        int      `json:"show_id"`
-	Title         string   `json:"title"`
-	CreditsString string   `json:"credits_string"`
-	Credits       []Credit `json:"credits"`
-	Description   string   `json:"description"`
-	ShowTypeID    int      `json:"show_type_id"`
-	Season        Link     `json:"seasons"`
-	EditLink      Link     `json:"editlink"`
-	ApplyLink     Link     `json:"applylink"`
-	MicroSiteLink Link     `json:"micrositelink"`
-	Photo         string   `json:"photo"`
+	ShowID        int               `json:"show_id"`
+	Title         string            `json:"title"`
+	CreditsString string            `json:"credits_string"`
+	Credits       []Credit          `json:"credits"`
+	Description   string            `json:"description"`
+	ShowTypeID    int               `json:"show_type_id"`
+	Season        Link              `json:"seasons"`
+	EditLink      Link              `json:"editlink"`
+	ApplyLink     Link              `json:"applylink"`
+	MicroSiteLink Link              `json:"micrositelink"`
+	Photo         string            `json:"photo"`
+	Subtype       ShowSeasonSubtype `json:"subtype"`
 }
 
 // Link represents a MyRadio action link.

--- a/subtype.go
+++ b/subtype.go
@@ -1,0 +1,7 @@
+package myradio
+
+type ShowSeasonSubtype struct {
+	SubtypeID string `json:"id"`
+	Name      string `json:"name"`
+	Class     string `json:"class"`
+}

--- a/subtype.go
+++ b/subtype.go
@@ -5,3 +5,8 @@ type ShowSeasonSubtype struct {
 	Name      string `json:"name"`
 	Class     string `json:"class"`
 }
+
+func (s *Session) GetAllShowSubtypes() (subtypes []ShowSeasonSubtype, err error) {
+	err = s.get("/showSubtype/all").Into(&subtypes)
+	return
+}


### PR DESCRIPTION
This is a big project, comprised of several PRs. See [here](https://github.com/orgs/UniversityRadioYork/teams/officers/discussions/1) for the plan (internal only). This PR is a continuation of https://github.com/UniversityRadioYork/MyRadio/pull/818

In this PR, the fields for show and season subtypes are added to myradio-go. The next phase will be to have 2016-site use them.

This PR depends on https://github.com/UniversityRadioYork/MyRadio/pull/824 in MyRadio.
