### PR TITLE
GetCurrentTimeslot(): handle there being no current timeslot

### DIFF
--- a/timeslot.go
+++ b/timeslot.go
@@ -216,7 +216,9 @@ func (s *Session) GetCurrentTimeslot() (timeslot Timeslot, err error) {
 	if err = s.get("/timeslot/currenttimeslot").Into(&timeslot); err != nil {
 		return
 	}
-	err = timeslot.populateTimeslotTimes()
+	if timeslot.TimeslotID != 0 {
+		err = timeslot.populateTimeslotTimes()
+	}
 	return
 }
 


### PR DESCRIPTION
I'd quite like to just return `nil`, but that'd involve changing the return type to `*Timeslot` which is a breaking change >:(