### PR TITLE
James more useful mock session

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -216,15 +216,19 @@ func (s *authedRequester) Do(r *Request) *Response {
 
 // mockRequester answers API requests by returning some stock response.
 type mockRequester struct {
-	message *json.RawMessage
+	messenger Messenger
 }
 
+type Messenger func(r *Request) []byte
+
 // MockRequester creates a new mocked requester.
-func MockRequester(message *json.RawMessage) Requester {
-	return &mockRequester{message: message}
+func MockRequester(messenger Messenger) Requester {
+	return &mockRequester{messenger: messenger}
 }
 
 // Do pretends to fulfil an API request, but actually returns the mockRequester's stock response.
 func (s *mockRequester) Do(r *Request) *Response {
-	return &Response{raw: s.message, err: nil}
+	rm := json.RawMessage{}
+	_ = rm.UnmarshalJSON(s.messenger(r))
+	return &Response{raw: &rm, err: nil}
 }

--- a/session.go
+++ b/session.go
@@ -2,7 +2,6 @@ package myradio
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/url"
 
 	"github.com/UniversityRadioYork/myradio-go/api"
@@ -31,11 +30,17 @@ func NewSessionForServer(apikey, server string) (*Session, error) {
 	return &Session{requester: api.NewRequester(apikey, *url)}, nil
 }
 
-// MockSession creates a new mocked API session returning the JSON message stored in message.
-func MockSession(message []byte) *Session {
-	rm := json.RawMessage{}
-	_ = rm.UnmarshalJSON(message)
-	return &Session{requester: api.MockRequester(&rm)}
+// StaticMockSession creates a new mocked API session returning the JSON message stored in message.
+func StaticMockSession(message []byte) *Session {
+	messenger := func(_ *api.Request) []byte {
+		return message
+	}
+	return &Session{requester: api.MockRequester(messenger)}
+}
+
+// MockSession creates a new mocked API session returning a JSON message defined by the messenger.
+func MockSession(messenger api.Messenger) *Session {
+	return &Session{requester: api.MockRequester(messenger)}
 }
 
 // do fulfils, a request for the given endpoint.
@@ -98,4 +103,3 @@ func NewSessionFromKeyFileForServer(server string) (*Session, error) {
 
 	return NewSessionForServer(apikey, server)
 }
-

--- a/session.go
+++ b/session.go
@@ -32,13 +32,10 @@ func NewSessionForServer(apikey, server string) (*Session, error) {
 }
 
 // MockSession creates a new mocked API session returning the JSON message stored in message.
-func MockSession(message []byte) (*Session, error) {
+func MockSession(message []byte) *Session {
 	rm := json.RawMessage{}
-	err := rm.UnmarshalJSON(message)
-	if err != nil {
-		return nil, err
-	}
-	return &Session{requester: api.MockRequester(&rm)}, nil
+	_ = rm.UnmarshalJSON(message)
+	return &Session{requester: api.MockRequester(&rm)}
 }
 
 // do fulfils, a request for the given endpoint.

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,124 @@
+package myradio_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	myradio "github.com/UniversityRadioYork/myradio-go"
+	"github.com/UniversityRadioYork/myradio-go/api"
+)
+
+func TestMockSession(t *testing.T) {
+	session := myradio.MockSession(func(r *api.Request) []byte {
+		endpoint := r.Endpoint
+		if strings.HasPrefix(endpoint, "/show") {
+			return []byte(getSearchMetaJson)
+		}
+		if strings.HasPrefix(endpoint, "/team") {
+			return []byte(positionJSON)
+		}
+		return []byte("")
+	})
+
+	expectedShow := []myradio.ShowMeta{{
+		ShowID:        8675309,
+		Title:         "Jenny I've Got Your Number",
+		CreditsString: "Tommy Tutone",
+		Credits: []myradio.Credit{
+			{
+				Type:     1,
+				MemberID: 666,
+				User: myradio.User{
+					MemberID:     666,
+					Fname:        "Tommy",
+					Sname:        "Tutone",
+					Email:        "tt500@example.com",
+					Receiveemail: false,
+					Photo:        "/media/image_meta/MyRadioImageMetadata/1.jpeg",
+					Bio:          "generic bio",
+				},
+			},
+		},
+		Description: "Tommy Tutone's got your number, and he's gotta make you his.",
+		ShowTypeID:  1,
+		Season: myradio.Link{
+			Display: "season display",
+			Value:   "https://myradio.example.com/seasons/512",
+			Title:   "Seasons",
+			URL:     "https://myradio.example.com/seasons/512",
+		},
+		EditLink: myradio.Link{
+			Display: "edit display",
+			Value:   "https://myradio.example.com/edit/8675309",
+			Title:   "Edit",
+			URL:     "https://myradio.example.com/edit/8675309",
+		},
+		ApplyLink: myradio.Link{
+			Display: "apply display",
+			Value:   "https://myradio.example.com/apply/8675309",
+			Title:   "Apply",
+			URL:     "https://myradio.example.com/apply/8675309",
+		},
+		MicroSiteLink: myradio.Link{
+			Display: "microsite display",
+			Value:   "https://myradio.example.com/microsites/8675309",
+			Title:   "Microsites",
+			URL:     "https://myradio.example.com/microsites/8675309",
+		},
+		Photo: "https://myradio.example.com/photos/shows/8675309",
+	}}
+
+	expectedTeams := []myradio.Officer{
+		{
+			User: myradio.User{
+				MemberID:     10,
+				Fname:        "John",
+				Sname:        "Smith",
+				Email:        "john.smith@example.org.uk",
+				Receiveemail: true,
+				Photo:        "/media/image_meta/MyRadioImageMetadata/1.jpeg",
+				Bio:          "generic bio",
+			},
+			From:            time.Unix(1479081600, 0),
+			FromRaw:         1479081600,
+			MemberOfficerID: 1,
+			Position: myradio.OfficerPosition{
+				OfficerID: 2,
+				Name:      "Station Manager",
+				Alias:     "station.manager",
+				Team: myradio.Team{
+					TeamID:      1,
+					Name:        "Station Management",
+					Alias:       "management",
+					Ordering:    10,
+					Description: "",
+					Status:      "c",
+				},
+				Ordering:    2,
+				Description: "",
+				Status:      "c",
+				Type:        "a",
+			},
+		},
+	}
+
+	showMeta, err := session.GetSearchMeta("tutone")
+	if err != nil {
+		t.Error(err)
+	}
+
+	heads, err := session.GetTeamHeadPositions(1, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(showMeta, expectedShow) {
+		t.Errorf("expected:\n%v\n\ngot:\n%v", expectedShow, showMeta)
+	}
+
+	if !reflect.DeepEqual(heads, expectedTeams) {
+		t.Errorf("expected:\n%v\n\ngot:\n%v", expectedTeams, heads)
+	}
+}

--- a/show_test.go
+++ b/show_test.go
@@ -107,10 +107,7 @@ func TestGetSearchMetaUnmarshal(t *testing.T) {
 		Photo: "https://myradio.example.com/photos/shows/8675309",
 	}}
 
-	session, err := myradio.MockSession([]byte(getSearchMetaJson))
-	if err != nil {
-		t.Error(err)
-	}
+	session := myradio.MockSession([]byte(getSearchMetaJson))
 
 	showMeta, err := session.GetSearchMeta("tutone")
 	if err != nil {

--- a/show_test.go
+++ b/show_test.go
@@ -107,7 +107,7 @@ func TestGetSearchMetaUnmarshal(t *testing.T) {
 		Photo: "https://myradio.example.com/photos/shows/8675309",
 	}}
 
-	session := myradio.MockSession([]byte(getSearchMetaJson))
+	session := myradio.StaticMockSession([]byte(getSearchMetaJson))
 
 	showMeta, err := session.GetSearchMeta("tutone")
 	if err != nil {

--- a/team_test.go
+++ b/team_test.go
@@ -79,10 +79,7 @@ func TestGetTeamHeadPositions(t *testing.T) {
 		},
 	}
 
-	session, err := myradio.MockSession([]byte(positionJSON))
-	if err != nil {
-		t.Error(err)
-	}
+	session := myradio.MockSession([]byte(positionJSON))
 
 	heads, err := session.GetTeamHeadPositions(1, nil)
 	if err != nil {
@@ -131,10 +128,7 @@ func TestGetTeamAssistantHeadPositions(t *testing.T) {
 		},
 	}
 
-	session, err := myradio.MockSession([]byte(positionJSON))
-	if err != nil {
-		t.Error(err)
-	}
+	session := myradio.MockSession([]byte(positionJSON))
 
 	heads, err := session.GetTeamAssistantHeadPositions(1, nil)
 	if err != nil {

--- a/team_test.go
+++ b/team_test.go
@@ -79,7 +79,7 @@ func TestGetTeamHeadPositions(t *testing.T) {
 		},
 	}
 
-	session := myradio.MockSession([]byte(positionJSON))
+	session := myradio.StaticMockSession([]byte(positionJSON))
 
 	heads, err := session.GetTeamHeadPositions(1, nil)
 	if err != nil {
@@ -128,7 +128,7 @@ func TestGetTeamAssistantHeadPositions(t *testing.T) {
 		},
 	}
 
-	session := myradio.MockSession([]byte(positionJSON))
+	session := myradio.StaticMockSession([]byte(positionJSON))
 
 	heads, err := session.GetTeamAssistantHeadPositions(1, nil)
 	if err != nil {

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -50,10 +50,7 @@ func TestGetWeekScheduleZero(t *testing.T) {
 
 	zeroes := [][]byte{[]byte("[]"), []byte("{}")}
 	for _, zero := range zeroes {
-		session, err := myradio.MockSession(zero)
-		if err != nil {
-			t.Error(err)
-		}
+		session := myradio.MockSession(zero)
 
 		schedule, err := session.GetWeekSchedule(0, 1)
 		if err != nil {

--- a/timeslot_test.go
+++ b/timeslot_test.go
@@ -50,7 +50,7 @@ func TestGetWeekScheduleZero(t *testing.T) {
 
 	zeroes := [][]byte{[]byte("[]"), []byte("{}")}
 	for _, zero := range zeroes {
-		session := myradio.MockSession(zero)
+		session := myradio.StaticMockSession(zero)
 
 		schedule, err := session.GetWeekSchedule(0, 1)
 		if err != nil {


### PR DESCRIPTION
Allow Mock sessions to mock multpile endpoints to aid testing of [2016-site](https://github.com/UniversityRadioYork/2016-site).

StaticMockSession() added to retain old simpler functionality for testing single endpoints.