### PR TITLE
Introduce api.Error type (and improve errors)

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,14 @@
+package api
+
+import "fmt"
+
+// Error is the error type returned when API requests result in an error.
+type Error struct {
+	Endpoint string
+	Code     int
+	Payload  string
+}
+
+func (a Error) Error() string {
+	return fmt.Sprintf("%s NOT OK: %d: %s", a.Endpoint, a.Code, a.Payload)
+}


### PR DESCRIPTION
This will let downstream consumers handle the different MyRadio response codes differently (for example, 2016-site rendering a 404 when MyRadio sends a 404, rather than a 404 for everything). Intended usage is

```go
something, err := session.DoAThing()
var apiErr api.Error
if errors.As(err, &apiErr) {
  // request succeeded, but MyRadio returned an error
  // do something with apiErr.Status
} else if err != nil {
  // something went wrong with making the request itself
}
```